### PR TITLE
Hotfix 6614

### DIFF
--- a/app/models/coverage_household.rb
+++ b/app/models/coverage_household.rb
@@ -116,32 +116,41 @@ class CoverageHousehold
     state :terminated
 
     event :move_to_contingent!, :after => :record_transition do
+      transitions from: :terminated, to: :terminated
+      transitions from: :canceled, to: :canceled
       transitions from: :unverified, to: :enrolled_contingent, after: :notify_verification_outstanding
+      transitions from: :enrollment_submitted, to: :enrolled_contingent, after: :notify_verification_outstanding
       transitions from: :enrolled_contingent, to: :enrolled_contingent
       transitions from: :enrolled, to: :enrolled_contingent, after: :notify_verification_outstanding
     end
 
     event :move_to_enrolled!, :after => :record_transition do
+      transitions from: :terminated, to: :terminated
+      transitions from: :canceled, to: :canceled
       transitions from: :unverified, to: :enrolled, after: :notify_verification_success
       transitions from: :enrolled_contingent, to: :enrolled, after: :notify_verification_success
       transitions from: :enrolled, to: :enrolled
+      transitions from: :enrollment_submitted, to: :enrolled, after: :notify_verification_success
     end
 
     event :move_to_pending!, :after => :record_transition do
+      transitions from: :terminated, to: :terminated
+      transitions from: :canceled, to: :canceled
       transitions from: :unverified, to: :unverified
       transitions from: :enrolled_contingent, to: :unverified
       transitions from: :enrolled, to: :unverified
+      transitions from: :enrollment_submitted, to: :unverified
     end
   end
 
   def self.update_individual_eligibilities_for(consumer_role)
-    found_families = Family.find_all_by_person(consumer_role.try(:person))
+    found_families = Family.find_all_by_person(consumer_role.person)
     found_families.each do |ff|
       ff.households.each do |hh|
         hh.coverage_households.each do |ch|
           ch.evaluate_individual_market_eligiblity
         end
-        hh.hbx_enrollments.active.each do |he|
+        hh.hbx_enrollments.each do |he|
           he.evaluate_individual_market_eligiblity
         end
       end

--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -224,6 +224,7 @@ class HbxEnrollment
     eligibility_ruleset = ::RuleSet::HbxEnrollment::IndividualMarketVerification.new(self)
     if eligibility_ruleset.applicable?
       self.send(eligibility_ruleset.determine_next_state)
+      self.save!
     end
   end
 
@@ -918,13 +919,18 @@ class HbxEnrollment
     end
 
     event :move_to_enrolled!, :after => :record_transition do
-      transitions from: :coverage_selected, to: :coverage_selected
+      transitions from: :inactive, to: :inactive
+      transitions from: :terminated, to: :terminated
+      transitions from: :coverage_canceled, to: :coverage_canceled
       transitions from: :unverified, to: :coverage_selected
       transitions from: :enrolled_contingent, to: :coverage_selected
       transitions from: :coverage_selected, to: :coverage_selected
     end
 
     event :move_to_contingent!, :after => :record_transition do
+      transitions from: :inactive, to: :inactive
+      transitions from: :terminated, to: :terminated
+      transitions from: :coverage_canceled, to: :coverage_canceled
       transitions from: :shopping, to: :enrolled_contingent
       transitions from: :coverage_selected, to: :enrolled_contingent
       transitions from: :unverified, to: :enrolled_contingent
@@ -933,6 +939,9 @@ class HbxEnrollment
     end
 
     event :move_to_pending!, :after => :record_transition do
+      transitions from: :inactive, to: :inactive
+      transitions from: :terminated, to: :terminated
+      transitions from: :coverage_canceled, to: :coverage_canceled
       transitions from: :shopping, to: :unverified
       transitions from: :unverified, to: :unverified
       transitions from: :coverage_selected, to: :unverified

--- a/app/models/rule_set/hbx_enrollment/individual_market_verification.rb
+++ b/app/models/rule_set/hbx_enrollment/individual_market_verification.rb
@@ -8,7 +8,8 @@ module RuleSet
       end
 
       def applicable?
-        hbx_enrollment.affected_by_verifications_made_today? && (!hbx_enrollment.benefit_sponsored?)
+        (!hbx_enrollment.plan_id.nil?) &&
+          hbx_enrollment.affected_by_verifications_made_today? && (!hbx_enrollment.benefit_sponsored?)
       end
 
       def roles_for_determination

--- a/spec/factories/families.rb
+++ b/spec/factories/families.rb
@@ -11,3 +11,19 @@ FactoryGirl.define do
     end
   end
 end
+
+FactoryGirl.define do
+  factory(:individual_market_family, class: Family) do
+    transient do
+      primary_person { FactoryGirl.create(:person, :with_consumer_role) }
+    end
+
+    family_members { [
+      FactoryGirl.create(:family_member, family: self, is_primary_applicant: true, is_active: true, person: primary_person)
+    ] }
+
+    after :create do |f, evaluator|
+      f.households.first.add_household_coverage_member(f.family_members.first)
+    end
+  end
+end

--- a/spec/models/coverage_household_spec.rb
+++ b/spec/models/coverage_household_spec.rb
@@ -26,7 +26,7 @@ describe CoverageHousehold, "when informed that eligiblity has changed for an in
   let(:mock_consumer_role) { double(person: mock_person) }
   let(:matching_coverage_household) { instance_double("CoverageHousehold") }
   let(:matching_hbx_enrollment) { instance_double("HbxEnrollment") }
-  let(:hbxs) { double(active: [matching_hbx_enrollment]) }
+  let(:hbxs) { [matching_hbx_enrollment] }
   let(:mock_household) { instance_double("Household", :coverage_households => [matching_coverage_household], hbx_enrollments: hbxs) }
   let(:mock_family) { instance_double("Family", :households => [mock_household]) }
 

--- a/spec/models/fedhub_result_propagation_spec.rb
+++ b/spec/models/fedhub_result_propagation_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+describe "A new consumer role with an individual market enrollment", :dbclean => :after_each do
+  let(:person) { FactoryGirl.create(:person, :with_consumer_role) }
+  let(:family) { FactoryGirl.create(:individual_market_family, primary_person: person) }
+  let(:hbx_profile) { FactoryGirl.create(:hbx_profile, :open_enrollment_coverage_period) }
+  let(:enrollment) do
+    benefit_sponsorship = hbx_profile.benefit_sponsorship
+    benefit_package = benefit_sponsorship.benefit_coverage_periods.first.benefit_packages.first
+    plan = Plan.find(benefit_package.benefit_ids.first)
+    enrollment = family.households.first.create_hbx_enrollment_from(
+      coverage_household: family.households.first.coverage_households.first,
+      consumer_role: person.consumer_role,
+      benefit_package: hbx_profile.benefit_sponsorship.benefit_coverage_periods.first.benefit_packages.first
+    )
+    enrollment.plan = plan
+    enrollment.select_coverage!
+    enrollment
+  end
+
+  describe "when lawful presence fails verification" do
+    let(:denial_information) do
+      Struct.new(:determined_at, :vlp_authority).new(Time.now, "ssa")
+    end
+
+    before :each do
+      enrollment
+      person.consumer_role.deny_lawful_presence!(denial_information)
+    end
+
+    describe "the enrollment" do
+      it "is now in the enrolled_contingent state" do
+        enroll = HbxEnrollment.by_hbx_id(enrollment.hbx_id).first
+        expect(enroll.aasm_state).to eql "enrolled_contingent"
+      end
+    end
+  end
+end

--- a/spec/models/rule_set/hbx_enrollment/individual_market_verificiation_spec.rb
+++ b/spec/models/rule_set/hbx_enrollment/individual_market_verificiation_spec.rb
@@ -2,9 +2,10 @@ require "rails_helper"
 
 describe RuleSet::HbxEnrollment::IndividualMarketVerification do
   subject { RuleSet::HbxEnrollment::IndividualMarketVerification.new(enrollment) }
-  let(:enrollment) { instance_double(HbxEnrollment, :affected_by_verifications_made_today? => is_currently_active, :benefit_sponsored? => is_shop_enrollment) }
+  let(:enrollment) { instance_double(HbxEnrollment, :affected_by_verifications_made_today? => is_currently_active, :benefit_sponsored? => is_shop_enrollment, :plan_id => plan_id) }
   let(:is_currently_active) { true }
   let(:is_shop_enrollment) { false }
+  let(:plan_id) { double }
 
   describe "for a shop policy" do
     let(:is_shop_enrollment) { true }
@@ -16,6 +17,7 @@ describe RuleSet::HbxEnrollment::IndividualMarketVerification do
 
   describe "for an inactive individual policy" do
     let(:is_currently_active) { false }
+
     it "should not be applicable" do
       expect(subject.applicable?).to eq false
     end


### PR DESCRIPTION
Statuses were not properly being communicated up to enrollments based on
lawful presence results.