### PR TITLE
Refs #5234. Validate & create 2-way relationships

### DIFF
--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -582,7 +582,7 @@ private
     primary_member_id = primary_family_member.id
     primary_person = primary_family_member.person
     other_family_members = family_members.select { |fm| (fm.id.to_s != primary_member_id.to_s) && fm.person.present? }
-    undefined_relations = other_family_members.any? { |fm| primary_person.find_relationship_with(fm.person).blank? }
+    undefined_relations = other_family_members.any? { |fm| primary_person.find_relationship_with(fm.person).blank? or fm.person.find_relationship_with(primary_person).blank? }
     errors.add(:family_members, "relationships between primary_family_member and all family_members must be defined") if undefined_relations
   end
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -373,6 +373,18 @@ class Person
         :relative_id => person.id
       })
     end
+
+    existing_reverse_relationship = person.person_relationships.detect do |rel|
+      rel.relative_id.to_s == id.to_s
+    end
+    if existing_reverse_relationship
+      existing_reverse_relationship.update_attributes(:kind => PersonRelationship::InverseMap[relationship])
+    else
+      person.person_relationships << PersonRelationship.new({
+        :kind => PersonRelationship::InverseMap[relationship],
+        :relative_id => id
+      })
+    end
   end
 
   def add_work_email(email)

--- a/spec/models/family_spec.rb
+++ b/spec/models/family_spec.rb
@@ -388,6 +388,42 @@ describe Family do
       expect(family.earliest_effective_sep).to eq @current_sep
     end
   end
+
+  describe '#all_family_member_relations_defined' do
+    let!(:husband) { FactoryGirl.build_stubbed :person, :male, first_name: 'Bill' }
+    let!(:wife) { FactoryGirl.build_stubbed :person, :female, first_name: 'Kelly' }
+
+    before :each do
+      husband.person_relationships << PersonRelationship.new({
+        :kind => 'spouse',
+        :relative_id => wife.id
+      })
+
+      family.family_members = [
+        FactoryGirl.build_stubbed(:family_member, is_active: true, is_primary_applicant: true, person: husband),
+        FactoryGirl.build_stubbed(:family_member, person: wife)
+      ]
+    end
+
+    context "with dependents not having relationships with primary_family_member" do
+      it 'is not valid' do
+        expect(family).to_not be_valid
+      end
+    end
+
+    context "with dependent having relationships with primary_family_member" do
+      before :each do
+        wife.person_relationships << PersonRelationship.new({
+          :kind => 'spouse',
+          :relative_id => husband.id
+        })
+      end
+
+      it "is valid" do
+        expect(family).to be_valid
+      end
+    end
+  end
 end
 
 describe "special enrollment periods" do

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -558,6 +558,53 @@ describe Person do
     end
   end
 
+  describe '#ensure_relationship_with' do
+    let!(:husband) { FactoryGirl.build_stubbed :person, :male, first_name: 'Bill' }
+    let!(:wife) { FactoryGirl.build_stubbed :person, :female, first_name: 'Kelly' }
+
+    context 'when no relationship exists between two people' do
+      before :each do
+        husband.ensure_relationship_with(wife, 'spouse')
+      end
+
+      it 'creates a relationship between husband and wife' do
+        expect(husband.person_relationships.any? { |r| r.relative_id == wife.id }).to be_truthy
+      end
+
+      it 'creates a relationship between wife and husband' do
+        expect(wife.person_relationships.any? { |r| r.relative_id == husband.id }).to be_truthy
+      end
+    end
+
+    context 'when a one sided relationship exists between two people' do
+      before :each do
+        husband.person_relationships << PersonRelationship.new({
+          :kind => 'spouse',
+          :relative_id => wife.id
+        })
+        wife.ensure_relationship_with(husband, 'spouse')
+      end
+
+      it "doesn't create a new relationship between husband and wife" do
+        expect(husband.person_relationships.count).to eq(1)
+      end
+
+      it 'creates a relationship between wife and husband' do
+        expect(wife.person_relationships.any? { |r| r.relative_id == husband.id }).to be_truthy
+      end
+    end
+
+    context 'when two people are parent/child' do
+      let!(:child) { FactoryGirl.build_stubbed :person, :male, first_name: 'Danny' }
+
+      before(:each) { husband.ensure_relationship_with(child, 'child') }
+
+      it 'creates a child relationship between child and parent' do
+        expect(child.person_relationships.detect { |fm| fm.relative_id == husband.id }.kind).to eq('parent')
+      end
+    end
+  end
+
   describe "with no relationship to a dependent" do
     describe "after ensure_relationship_with" do
       it "should have the new relationship"


### PR DESCRIPTION
Change the Family#all_family_member_relations_defined to check for
relationships between a family member and the family's
primary_family_member, previously it was just the other way around. Also
change Person#ensure_relationship_with to create relationships both
ways.