### PR TITLE
Refs #7873 brokers employers page performance

### DIFF
--- a/app/controllers/broker_agencies/profiles_controller.rb
+++ b/app/controllers/broker_agencies/profiles_controller.rb
@@ -143,12 +143,8 @@ class BrokerAgencies::ProfilesController < ApplicationController
       broker_role_id = current_user.person.broker_role.id
       @orgs = Organization.by_broker_role(broker_role_id)
     end
-
-    @page_alphabets = page_alphabets(@orgs, "legal_name")
-    page_no = cur_page_no(@page_alphabets)
-    @organizations = @orgs.where("legal_name" => /^#{page_no}/i) unless @orgs.blank?
-    @employer_profiles = @organizations.map {|o| o.employer_profile} unless @orgs.blank?
-
+    @employer_profiles = @orgs.map {|o| o.employer_profile} unless @orgs.blank?
+    @memo = {}
     @broker_role = current_user.person.broker_role || nil
     @general_agency_profiles = GeneralAgencyProfile.all_by_broker_role(@broker_role, approved_only: true)
   end

--- a/app/models/employer_profile.rb
+++ b/app/models/employer_profile.rb
@@ -156,7 +156,19 @@ class EmployerProfile
     end
   end
 
+  def memoize_active_broker active_broker_memo
+    return unless account = active_broker_agency_account
+    if memo = active_broker_memo[account.broker_agency_profile_id] then return memo end
+    active_broker_memo[account.broker_agency_profile.id] = active_broker
+  end
+
   # for General Agency
+  def hashed_active_general_agency_legal_name gaps
+    return  unless account = active_general_agency_account
+    gap = gaps.detect{|gap| gap.id == account.general_agency_profile_id}
+    gap && gap.legal_name
+  end
+
   def active_general_agency_legal_name
     if active_general_agency_account
       active_general_agency_account.legal_name

--- a/app/views/broker_agencies/profiles/_employers.html.erb
+++ b/app/views/broker_agencies/profiles/_employers.html.erb
@@ -3,7 +3,6 @@
     <div id= 'message_form'></div>
     <div class="top-pd" id="inbox_provider_form">
       <span class="flash_message"></span>
-
       <%= form_tag(update_assign_broker_agencies_profile_path(id: @broker_agency_profile.id), method: :post, remote: true) do %>
         <table id="employers_dataTable" class="table table-striped table-bordered dataTable">
           <thead>
@@ -43,8 +42,8 @@
                   <% if controller_name == 'profiles' %>
                     <% if er.active_broker_agency_account.present? %>
                       <% broker_agency_profile = er.active_broker_agency_account.broker_agency_profile %>
-                      <% edit_path = edit_broker_agencies_profile_applicant_path(broker_agency_profile, er.active_broker) %>
-                        <td><%= link_to er.active_broker.full_name, edit_path, class: "interaction-click-control-broker-show", method: :get %></td>
+                      <% edit_path = edit_broker_agencies_profile_applicant_path(broker_agency_profile, er.memoize_active_broker(@memo)) %>
+                        <td><%= link_to er.memoize_active_broker(@memo).full_name, edit_path, class: "interaction-click-control-broker-show", method: :get %></td>
                     <% else %>
                         <td></td>
                     <% end %>
@@ -57,7 +56,7 @@
                     <% end %>
                   <% end %>
                   <td class='general_agency'>
-                    <%= er.active_general_agency_legal_name %>
+                    <%= er.hashed_active_general_agency_legal_name(@general_agency_profiles) %>
                       &nbsp;
                     <%= link_to 'clear assign', clear_assign_for_employer_broker_agencies_profile_path(id: @broker_agency_profile.id, employer_id: er.id), method: :post, remote: true if er.active_general_agency_account.present? && controller_name == 'profiles' %>
                   </td>


### PR DESCRIPTION
### Redmine ticket(s)
* https://devops.dchbx.org/redmine/issues/7873

### Local build result revised June 26
bundle exec rake parallel:spec[4]
3926 examples, 0 failures, 82 pendings

Took 160 seconds (2:40)
bundle exec cucumber
48 scenarios (48 passed)
916 steps (916 passed)
5m32.882s

### Latest rebase/merge tag
*
master e9f146b5e3d48f37582a4212fd3d51d5c36d2979
---

### Data ticket(s) Followup
* (redmine links here - optional)

### Related Pull Requests
* (github links here - optional)

---

### TODOs / Notes
#### Peer Review
The performance is slow because this datatables pattern loads an entire tables rather than a single page
Two issues become visible
  - more database hits (this is addressed in this fix, Golden & Co goes from 12-15 secs to 3-4 secs
  - more rendering time (not addressed)

#### Functional Testing
* When brokers look at their employers page worst case is now 3-4 seconds not 12-15 secs.
This patch should be deployed while further tuning occurs.

#### Deployment
* This single commit is based off the most recent master.    It is the result of force pushing after multiple tries to optimize performance, so there may be a conflict merging into stage in case a previous version was merged there.   This could go directly as a hotfix.

