### PR TITLE
Refs #8070 Filtering out the non self-assisted QLEs from UI for SHOP …

### DIFF
--- a/app/controllers/insured/families_controller.rb
+++ b/app/controllers/insured/families_controller.rb
@@ -250,9 +250,17 @@ class Insured::FamiliesController < FamiliesController
       @qualifying_life_events += QualifyingLifeEventKind.send @manually_picked_role if @manually_picked_role
     else
       if @person.active_employee_roles.present?
-        @qualifying_life_events += QualifyingLifeEventKind.shop_market_events
+        if current_user.has_hbx_staff_role?
+          @qualifying_life_events += QualifyingLifeEventKind.shop_market_events_admin
+        else
+          @qualifying_life_events += QualifyingLifeEventKind.shop_market_events
+        end
       else @person.consumer_role.present?
-        @qualifying_life_events += QualifyingLifeEventKind.individual_market_events
+        if current_user.has_hbx_staff_role?
+          @qualifying_life_events += QualifyingLifeEventKind.individual_market_events_admin
+        else
+          @qualifying_life_events += QualifyingLifeEventKind.individual_market_events
+        end
       end
     end
 

--- a/app/controllers/insured/families_controller.rb
+++ b/app/controllers/insured/families_controller.rb
@@ -252,7 +252,7 @@ class Insured::FamiliesController < FamiliesController
       if @person.active_employee_roles.present?
         @qualifying_life_events += QualifyingLifeEventKind.shop_market_events
       else @person.consumer_role.present?
-      @qualifying_life_events += QualifyingLifeEventKind.individual_market_events
+        @qualifying_life_events += QualifyingLifeEventKind.individual_market_events
       end
     end
 

--- a/app/controllers/insured/families_controller.rb
+++ b/app/controllers/insured/families_controller.rb
@@ -246,7 +246,9 @@ class Insured::FamiliesController < FamiliesController
     @qualifying_life_events = []
     if @person.has_multiple_roles?
       if current_user.has_hbx_staff_role?
-        @qualifying_life_events += QualifyingLifeEventKind.shop_market_events_admin + QualifyingLifeEventKind.individual_market_events_admin
+        @multiroles = @person.has_multiple_roles?
+        @manually_picked_role = params[:market] ? params[:market] : "shop_market_events"
+        @qualifying_life_events += QualifyingLifeEventKind.send @manually_picked_role + '_admin' if @manually_picked_role
       else
         @multiroles = @person.has_multiple_roles?
         @manually_picked_role = params[:market] ? params[:market] : "shop_market_events"

--- a/app/controllers/insured/families_controller.rb
+++ b/app/controllers/insured/families_controller.rb
@@ -245,9 +245,13 @@ class Insured::FamiliesController < FamiliesController
     end
     @qualifying_life_events = []
     if @person.has_multiple_roles?
-      @multiroles = @person.has_multiple_roles?
-      @manually_picked_role = params[:market] ? params[:market] : "shop_market_events"
-      @qualifying_life_events += QualifyingLifeEventKind.send @manually_picked_role if @manually_picked_role
+      if current_user.has_hbx_staff_role?
+        @qualifying_life_events += QualifyingLifeEventKind.shop_market_events_admin + QualifyingLifeEventKind.individual_market_events_admin
+      else
+        @multiroles = @person.has_multiple_roles?
+        @manually_picked_role = params[:market] ? params[:market] : "shop_market_events"
+        @qualifying_life_events += QualifyingLifeEventKind.send @manually_picked_role if @manually_picked_role
+      end
     else
       if @person.active_employee_roles.present?
         if current_user.has_hbx_staff_role?

--- a/app/models/qualifying_life_event_kind.rb
+++ b/app/models/qualifying_life_event_kind.rb
@@ -172,11 +172,11 @@ class QualifyingLifeEventKind
 
   class << self
     def shop_market_events
-      where(:market_kind => "shop").active.to_a
+      where(:market_kind => "shop").and(:is_self_attested.ne => false).active.to_a
     end
 
     def individual_market_events
-      where(:market_kind => "individual").active.to_a
+      where(:market_kind => "individual").and(:is_self_attested.ne => false).active.to_a
     end
   end
 

--- a/app/models/qualifying_life_event_kind.rb
+++ b/app/models/qualifying_life_event_kind.rb
@@ -178,6 +178,14 @@ class QualifyingLifeEventKind
     def individual_market_events
       where(:market_kind => "individual").and(:is_self_attested.ne => false).active.to_a
     end
+
+    def shop_market_events_admin
+      where(:market_kind => "shop").active.to_a
+    end
+
+    def individual_market_events_admin
+      where(:market_kind => "individual").active.to_a
+    end
   end
 
 end

--- a/spec/controllers/insured/families_controller_spec.rb
+++ b/spec/controllers/insured/families_controller_spec.rb
@@ -377,6 +377,7 @@ RSpec.describe Insured::FamiliesController do
       allow(person).to receive(:has_active_employee_role?).and_return(false)
       allow(person).to receive(:has_active_consumer_role?).and_return(true)
       allow(person).to receive(:has_multiple_roles?).and_return(true)
+      allow(user).to receive(:has_hbx_staff_role?).and_return(false)
       allow(person).to receive(:active_employee_roles).and_return(employee_role)
       get :find_sep, hbx_enrollment_id: "2312121212", change_plan: "change_plan"
     end

--- a/spec/models/qualifying_life_event_kind_spec.rb
+++ b/spec/models/qualifying_life_event_kind_spec.rb
@@ -42,6 +42,29 @@ RSpec.describe QualifyingLifeEventKind, :type => :model do
         expect(QualifyingLifeEventKind.individual_market_events.first).to be_instance_of QualifyingLifeEventKind
       end
     end
+
+
+    context "should only display self-attested QLEs" do
+
+      it "should display self-attested QLEs for shop market" do
+        expect(QualifyingLifeEventKind.shop_market_events.first.is_self_attested == true)
+      end
+
+      it "should display self-attested QLEs for individual market" do
+        expect(QualifyingLifeEventKind.individual_market_events.first.is_self_attested == true)
+      end
+
+      it "should not display non-self-attested QLEs for shop market" do
+        expect(QualifyingLifeEventKind.shop_market_events.first.is_self_attested == false)
+      end
+
+      it "should not display non-self-attested QLEs for individual market" do
+        expect(QualifyingLifeEventKind.individual_market_events.first.is_self_attested == false)
+      end
+
+    end
+
+
   end
 
   describe "instance methods" do


### PR DESCRIPTION
### Redmine ticket(s)
https://devops.dchbx.org/redmine/issues/8070

### Local build result

```
bundle exec rake parallel:spec[4]
3967 examples, 0 failures, 79 pendings
Took 135 seconds (2:15)

bundle exec cucumber
48 scenarios (48 passed)
916 steps (916 passed)
5m53.434s
```

### Latest rebase/merge tag
1.8.21
---

### Data ticket(s) Followup
* (redmine links here - optional)

### Related Pull Requests
* (github links here - optional)

---

### TODOs / Notes
#### Peer Review
1. Verified that the hbx admin can see all shop and ivl qle's when a user has multiple roles.
2. All rspecs and cucumber are passing.

#### Functional Testing
* (For testing locally)

#### Deployment
* (for release manager and/or build manager)

…& IVL