### PR TITLE
Bug 8025:Fixing bug IVL SPE's for users with dual EE/IVL role

### DIFF
--- a/app/controllers/insured/families_controller.rb
+++ b/app/controllers/insured/families_controller.rb
@@ -139,7 +139,7 @@ class Insured::FamiliesController < FamiliesController
     end
 
     @qualified_date = (start_date <= @qle_date && @qle_date <= end_date) ? true : false
-    if @person.has_active_employee_role? && !(@qle.present? && @qle.market_kind == "individual")
+    if @person.has_active_employee_role? && !(@qle.present? && @qle.individual?)
     @future_qualified_date = (@qle_date > TimeKeeper.date_of_record) ? true : false
     end
   end

--- a/app/controllers/insured/families_controller.rb
+++ b/app/controllers/insured/families_controller.rb
@@ -139,7 +139,7 @@ class Insured::FamiliesController < FamiliesController
     end
 
     @qualified_date = (start_date <= @qle_date && @qle_date <= end_date) ? true : false
-    if @person.has_active_employee_role?
+    if @person.has_active_employee_role? && !(@qle.present? && @qle.market_kind == "individual")
     @future_qualified_date = (@qle_date > TimeKeeper.date_of_record) ? true : false
     end
   end


### PR DESCRIPTION
### Redmine ticket(s)
* https://devops.dchbx.org/redmine/issues/8025

For User's with dual EE/IVL roles, if user is doing IVL SPE's, user should allowed for special enrollment unlike he should not thrown with EE SPE's error messages.

### Local build result

```
bundle exec rake parallel:spec[4]
Finished in 6 minutes 25 seconds (files took 11.63 seconds to load)
2095 examples, 0 failures, 32 pending
4000 examples, 0 failures, 78 pendings

Took 403 seconds (6:43)
bundle exec cucumber

49 scenarios (49 passed)
934 steps (934 passed)
7m21.948s
```

### Latest rebase/merge tag
* 1.8.32

---

### Data ticket(s) Followup
* (redmine links here - optional)

### Related Pull Requests
* (github links here - optional)

---

### TODOs / Notes
#### Peer Review
1. Verified that when making ivl qle changes with future dates, only ivl error are being shown.
2. All rspecs and cucumber specs are passing. 

#### Functional Testing
* (For testing locally)

#### Deployment
* (for release manager and/or build manager)