### PR TITLE
Bug dual role SEP-8446

### DIFF
--- a/app/controllers/insured/group_selection_controller.rb
+++ b/app/controllers/insured/group_selection_controller.rb
@@ -32,6 +32,9 @@ class Insured::GroupSelectionController < ApplicationController
       @benefit = benefit_package.first
       @aptc_blocked = @person.primary_family.is_blocked_by_qle_and_assistance?(nil, session["individual_assistance_path"])
     end
+    if (@change_plan == 'change_by_qle' or @enrollment_kind == 'sep')
+      @disable_market_kind = @market_kind == "shop" ? "individual" : "shop"
+    end
     insure_hbx_enrollment_for_shop_qle_flow
     @waivable = @hbx_enrollment.can_complete_shopping? if @hbx_enrollment.present?
     @new_effective_on = HbxEnrollment.calculate_effective_on_from(

--- a/app/views/insured/group_selection/new.html.erb
+++ b/app/views/insured/group_selection/new.html.erb
@@ -66,7 +66,7 @@
                 <% Plan::MARKET_KINDS.each_with_index do |kind, index| %>
                   <div class="n-radio-row">
                     <label class="n-radio" for="market_kind_<%= kind %>">
-                      <%= radio_button_tag 'market_kind', kind, index == 0, id: "market_kind_#{kind}", required: true, class: "n-radio" %>
+                      <%= radio_button_tag 'market_kind', kind, index == 0, id: "market_kind_#{kind}", required: true, class: "n-radio", checked: (@market_kind == kind), disabled: (@disable_market_kind == kind) %>
                       <span class="n-radio">
                       </span>
                       <% if kind=="shop" %>

--- a/spec/controllers/insured/group_selection_controller_spec.rb
+++ b/spec/controllers/insured/group_selection_controller_spec.rb
@@ -106,6 +106,19 @@ RSpec.describe Insured::GroupSelectionController, :type => :controller do
       expect(assigns(:hbx_enrollment)).not_to eq hbx_enrollment
     end
 
+    it "should disable individual market kind if selected market kind is shop in dual role SEP" do
+      allow(household).to receive(:hbx_enrollments).and_return(hbx_enrollments)
+      allow(hbx_enrollments).to receive(:shop_market).and_return(hbx_enrollments)
+      allow(hbx_enrollments).to receive(:enrolled_and_renewing).and_return(hbx_enrollments)
+      allow(hbx_enrollments).to receive(:effective_desc).and_return([hbx_enrollment])
+      allow(hbx_enrollment).to receive(:may_terminate_coverage?).and_return true
+      allow(hbx_enrollment).to receive(:can_complete_shopping?).and_return true
+
+      sign_in user
+      get :new, person_id: person.id, employee_role_id: employee_role.id, change_plan: 'change_by_qle', market_kind: 'shop', consumer_role_id: consumer_role.id
+      expect(assigns(:disable_market_kind)).to eq "individual"
+    end
+
     context "individual" do
       let(:hbx_profile) {double(benefit_sponsorship: benefit_sponsorship)}
       let(:benefit_sponsorship) {double(benefit_coverage_periods: [benefit_coverage_period])}


### PR DESCRIPTION
### Redmine ticket(s)
* https://devops.dchbx.org/redmine/issues/8446

### Local build result

```
bundle exec rake parallel:spec[4]

Finished in 6 minutes 49 seconds (files took 9.06 seconds to load)
2063 examples, 0 failures, 25 pending
4123 examples, 0 failures, 78 pendings
Took 430 seconds (7:10)

bundle exec cucumber
58 scenarios (58 passed)
1001 steps (1001 passed)
129m27.669s
```

### screenshot

User with dual role if user is doing SEP in individual market
in Market place Indiviual radio button should be locked because he selected individual market and should be allowed to shop in individual market kind only.


### Latest rebase/merge tag
*

---

### Data ticket(s) Followup
* (redmine links here - optional)

### Related Pull Requests
* (github links here - optional)

---

### TODOs / Notes
#### Peer Review
* (For code review)

#### Functional Testing
* (For testing locally)

#### Deployment
* (for release manager and/or build manager)