### PR TITLE
Mobile APIs: Feature request to support multiple contacts per employer client (#2)

### DIFF
--- a/app/views/broker_agencies/profiles/employers_api.json.erb
+++ b/app/views/broker_agencies/profiles/employers_api.json.erb
@@ -5,6 +5,7 @@
       @employer_details.each do |detail| 
         er = detail[:profile] 
         year = er.show_plan_year 
+        contacts = detail[:contacts]
     %><%= ',' unless first_element %>
       {
          "employer_name" : "<%= er.legal_name %>",
@@ -33,23 +34,18 @@
          "minimum_participation_required": null,
       <% end %>
          "estimated_premium": {
+            "billing_report_date": "<%= detail[:billing_report_date] %>",
+            "total_premium": <%= detail[:total_premium] %>,
             "employee_contribution": <%= detail[:employee_contribution] %>,
             "employer_contribution": <%= detail[:employer_contribution] %>
          },
-         "contact_info": {
-                <% office = er.organization.primary_office_location %>
-               "phone": "<%= office.phone.area_code %>-<%= office.phone.number %>",
-               "emails": <%= detail[:emails].to_json.html_safe %>,
-               "address_1": "<%= office.address.address_1 %>",
-               "address_2": "<%= office.address.address_2 %>",
-               "city": "<%= office.address.city %>",
-               "state": "<%= office.address.state %>",
-               "zip": "<%= office.address.zip %>"
-         },
+         "contact_info": [
+            <%= raw(contacts.map { |c| JSON.pretty_generate(c.to_h) }.join(",\n")) %>
+         ],
           "active_general_agency": "<%= er.active_general_agency_legal_name %>"
       }<% 
 
         first_element = false
       end %>
     ]
-} 
+}

--- a/spec/controllers/broker_agencies/profiles_controller_spec.rb
+++ b/spec/controllers/broker_agencies/profiles_controller_spec.rb
@@ -199,20 +199,46 @@ RSpec.describe BrokerAgencies::ProfilesController do
     let(:broker_role) {FactoryGirl.build(:broker_role)}
     let(:person) {double("person", broker_role: broker_role)}
     let(:user) { double("user", :has_hbx_staff_role? => true, :has_employer_staff_role? => false, :person => person)}
-    let(:organization) {FactoryGirl.create(:organization)}
+    let(:organization) {
+      o = FactoryGirl.create(:employer)
+      o.primary_office_location.address.address_1 = '500 Employers-Api Avenue'      
+      o.primary_office_location.address.address_2 = '#555' 
+      o.primary_office_location.phone = Phone.new(:kind => 'main', :area_code => '202', :number => '555-9999')
+      o.save
+      o
+    }
     let(:broker_agency_profile) { FactoryGirl.create(:broker_agency_profile, organization: organization) }
 
     let(:staff_user) { FactoryGirl.create(:user) }
     let(:staff) do
       s = FactoryGirl.create(:person, :with_work_email, :male)
       s.user = staff_user
+      s.first_name = "Seymour"
+      s.emails.clear
+      s.emails << ::Email.new(:kind => 'work', :address => 'seymour@example.com')
+      s.phones << ::Phone.new(:kind => 'mobile', :area_code => '202', :number => '555-0000')
+      s.save
+      s
+    end
+
+    let(:staff_user2) { FactoryGirl.create(:user) }
+    let(:staff2) do
+      s = FactoryGirl.create(:person, :with_work_email, :male)
+      s.user = staff_user2
+      s.first_name = "Beatrice"
+      s.emails.clear
+      s.emails << ::Email.new(:kind => 'work', :address => 'beatrice@example.com')
+      s.phones << ::Phone.new(:kind => 'work', :area_code => '202', :number => '555-0001')
+      s.phones << ::Phone.new(:kind => 'mobile', :area_code => '202', :number => '555-0002')
+      s.save
       s
     end
 
     let (:broker_agency_account) { FactoryGirl.build(:broker_agency_account, broker_agency_profile: broker_agency_profile) }
     let (:employer_profile) do 
-      e = FactoryGirl.create(:employer_profile) 
-      e.broker_agency_accounts << broker_agency_account      
+      e = FactoryGirl.create(:employer_profile, organization: organization) 
+      e.broker_agency_accounts << broker_agency_account 
+      e.save   
       e
     end
     
@@ -226,17 +252,37 @@ RSpec.describe BrokerAgencies::ProfilesController do
       )
 
       staff.employer_staff_roles << FactoryGirl.create(:employer_staff_role, employer_profile_id: employer_profile.id)
+      staff2.employer_staff_roles << FactoryGirl.create(:employer_staff_role, employer_profile_id: employer_profile.id)
       allow(user).to receive(:has_broker_agency_staff_role?).and_return(true)
       sign_in user
       xhr :get, :employers_api, id: broker_agency_profile.id, format: :json
       expect(response).to have_http_status(:success)
-      expect(assigns(:employer_details).count).to eq 1
-      expect(assigns(:employer_details)[0][:emails]).to include(staff.work_email.address)
-      expect(assigns(:employer_details)[0][:profile]).to eq employer_profile
-      expect(assigns(:employer_details)[0][:total_premium]).to eq 5500
-      expect(assigns(:employer_details)[0][:employee_contribution]).to eq 2200
-      expect(assigns(:employer_details)[0][:employer_contribution]).to eq 3300
+      details = assigns[:employer_details]
+      detail = details[0]
+      expect(details.count).to eq 1
+      expect(detail[:profile]).to eq employer_profile
+      expect(detail[:total_premium]).to eq 5500
+      expect(detail[:employee_contribution]).to eq 2200
+      expect(detail[:employer_contribution]).to eq 3300
+      contacts = detail[:contacts]
 
+      seymour = contacts.detect { |c| c.first == 'Seymour' }
+      beatrice = contacts.detect { |c| c.first == 'Beatrice' }
+      office = contacts.detect { |c| c.first == 'Primary' }
+      expect(seymour.mobile).to eq '(202) 555-0000'
+      expect(seymour.phone).to eq ''
+      expect(beatrice.phone).to eq '(202) 555-0001'
+      expect(beatrice.mobile).to eq '(202) 555-0002'
+      expect(seymour.emails).to include('seymour@example.com')
+      expect(beatrice.emails).to include('beatrice@example.com')
+      expect(office.phone).to eq '(202) 555-9999'
+      expect(office.address_1).to eq '500 Employers-Api Avenue'
+      expect(office.address_2).to eq '#555'
+      expect(office.city).to eq 'Washington'
+      expect(office.state).to eq 'DC'
+      expect(office.zip).to eq '11117'
+
+      
       allow_any_instance_of(EmployerProfile).to receive(:enrollments_for_billing).and_call_original
     end
   end


### PR DESCRIPTION
Changes to the Mobile API to support multiple contacts per employer client; see https://github.com/dchealthlink/HBX-mobile-app-APIs for context. 

Includes (squashed commits from feature branch on fork):
* test-first restructuring of controller to handle multiple contacts
* added tests & implementation for multiple phones and emails
* added multiple contact handling to json.erb
* prettier JSON
* billing_report_date and total_premium added to json response from api

### Redmine ticket(s)
* https://devops.dchbx.org/redmine/issues/8029

### Local build result

```
bundle exec rake parallel:spec[4]
bundle exec cucumber
```

### Latest rebase/merge tag
*

---

### Data ticket(s) Followup
* (redmine links here - optional)

### Related Pull Requests
* https://github.com/dchbx/enroll/pull/171 (earlier work on API)
* https://github.com/dchbx/enroll/pull/206 (earlier attempt to merge this code, aborted and recreated here due to branching problems)

---

### TODOs / Notes
#### Peer Review
* (For code review)

#### Functional Testing
* (For testing locally)

#### Deployment
* (for release manager and/or build manager)
