### PR TITLE
Refs #8800. Fix policy rendering.

### DIFF
--- a/spec/controllers/events/policies_controller_spec.rb
+++ b/spec/controllers/events/policies_controller_spec.rb
@@ -22,13 +22,47 @@ describe Events::PoliciesController do
 
     describe "for an existing policy" do
       let(:found_policys) { [policy] }
+      let(:eligibility_event_kind) { "some event like open enrollment maybe?" }
+
+      before :each do
+        allow(policy).to receive(:eligibility_event_kind).and_return(eligibility_event_kind)
+      end
 
       it "should send out a message to the bus with the rendered policy object" do
         expect(exchange).to receive(:publish).with(rendered_template, {
           :routing_key => reply_to_key,
           :headers => {
             :policy_id => policy_id,
-            :return_status => "200"
+            :return_status => "200",
+            :eligibility_event_kind => eligibility_event_kind
+          }       
+        })
+        controller.resource(connection, di, props, "")
+      end
+    end
+
+    describe "for a policy which cannot be properly rendered" do
+      let(:found_policys) { [policy] }
+      let(:exception) { Exception.new("Some exception") }
+      let(:exception_backtrace) { ["some error message on a line"] }
+
+      before :each do
+        allow(controller).to receive(:render_to_string).with(
+          "events/hbx_enrollment/policy", {:formats => ["xml"], :locals => {
+            :hbx_enrollment => policy
+          }}).and_raise(exception)
+        allow(exception).to receive(:backtrace).and_return(exception_backtrace)
+      end
+
+      it "should send out a message to the bus with the error code and exception" do
+        expect(exchange).to receive(:publish).with(JSON.dump({
+           exception: exception.inspect,
+           backtrace: exception_backtrace.inspect 
+          }), {
+          :routing_key => reply_to_key,
+          :headers => {
+            :policy_id => policy_id,
+            :return_status => "500"
           }       
         })
         controller.resource(connection, di, props, "")


### PR DESCRIPTION
### Redmine ticket(s)
* https://devops.dchbx.org/redmine/issues/8800

### Local build result

```
bundle exec rake parallel:spec[4]
4159 examples, 0 failures, 78 pendings

Took 222 seconds (3:42)
```

### Latest rebase/merge tag
* master

---

#### Peer Review
* (For code review)

#### Functional Testing
* (For testing locally)

Previously when responding to a policy request, if there was an error
the service would simply not respond.  Now the service will correctly
respond with error code 500.