### PR TITLE
Refs #9811 added renewing_canceled to INELIGIBLE_FOR_EXPORT_STATES.

### DIFF
--- a/app/models/plan_year.rb
+++ b/app/models/plan_year.rb
@@ -10,7 +10,7 @@ class PlanYear
   RENEWING  = %w(renewing_draft renewing_published renewing_enrolling renewing_enrolled)
   RENEWING_PUBLISHED_STATE = %w(renewing_published renewing_enrolling renewing_enrolled)
 
-  INELIGIBLE_FOR_EXPORT_STATES = %w(draft publish_pending eligibility_review published_invalid canceled renewing_draft suspended terminated ineligible expired)
+  INELIGIBLE_FOR_EXPORT_STATES = %w(draft publish_pending eligibility_review published_invalid canceled renewing_draft suspended terminated ineligible expired renewing_canceled)
 
   # Plan Year time period
   field :start_on, type: Date


### PR DESCRIPTION
### Redmine ticket(s)
https://devops.dchbx.org/redmine/issues/9811

### Local build result

```
bundle exec rake parallel:spec[4]
4268 examples, 0 failures, 78 pendings

Took 191 seconds (3:11)

bundle exec cucumber
58 scenarios (58 passed)
1001 steps (1001 passed)
6m33.024s
```

### Latest rebase/merge tag
*

---

### Data ticket(s) Followup
* (redmine links here - optional)

### Related Pull Requests
* (github links here - optional)

---

### TODOs / Notes
The umbrella spec "describe PlanYear, "which has the concept of export eligibility"  in models/plan_year_spec.rb covers this change

#### Peer Review
* (For code review)

#### Functional Testing
* (For testing locally)

#### Deployment
* (for release manager and/or build manager)

The umbrella spec "describe PlanYear, "which has the concept of export eligibility" covers this change