### PR TITLE
Refs #9871 developer permission is read only

### DIFF
--- a/app/data_migrations/define_permissions.rb
+++ b/app/data_migrations/define_permissions.rb
@@ -36,16 +36,19 @@ class DefinePermissions < MigrationTask
     u3 = User.create( email: 'themanda.csr_supervisor@dc.gov', password: 'P@55word', password_confirmation: 'P@55word', oim_id: "ex#{rand(5999999)+a}")
     u4 = User.create( email: 'themanda.csr_tier1@dc.gov', password: 'P@55word', password_confirmation: 'P@55word',  oim_id: "ex#{rand(5999999)+a}")
     u5 = User.create( email: 'themanda.csr_tier2@dc.gov', password: 'P@55word', password_confirmation: 'P@55word', oim_id: "ex#{rand(5999999)+a}")
-    hbx_profile_id = HbxProfile.all.first.id
+    u6 = User.create( email: 'developer@dc.gov', password: 'P@55word', password_confirmation: 'P@55word', oim_id: "ex#{rand(5999999)+a}")
+    hbx_profile_id = FactoryGirl.create(:hbx_profile).id
     p1 = Person.create( first_name: 'staff', last_name: "amanda#{rand(1000000)}", user: u1)
     p2 = Person.create( first_name: 'read_only', last_name: "amanda#{rand(1000000)}", user: u2)
     p3 = Person.create( first_name: 'supervisor', last_name: "amanda#{rand(1000000)}", user: u3)
     p4 = Person.create( first_name: 'tier1', last_name: "amanda#{rand(1000000)}", user: u4)
     p5 = Person.create( first_name: 'tier2', last_name: "amanda#{rand(1000000)}", user: u5)
+    p6 = Person.create( first_name: 'developer', last_name: "developer#{rand(1000000)}", user: u6)
     HbxStaffRole.create!( person: p1, permission_id: Permission.hbx_staff.id, subrole: 'hbx_staff', hbx_profile_id: hbx_profile_id)
     HbxStaffRole.create!( person: p2, permission_id: Permission.hbx_read_only.id, subrole: 'hbx_read_only', hbx_profile_id: hbx_profile_id)
     HbxStaffRole.create!(  person: p3, permission_id: Permission.hbx_csr_supervisor.id, subrole: 'hbx_csr_supervisor', hbx_profile_id: hbx_profile_id)
     HbxStaffRole.create!( person: p4, permission_id: Permission.hbx_csr_tier1.id, subrole: 'hbx_csr_tier1', hbx_profile_id: hbx_profile_id)
     HbxStaffRole.create!( person: p5, permission_id: Permission.hbx_csr_tier2.id, subrole: 'hbx_csr_tier2', hbx_profile_id: hbx_profile_id)
+    HbxStaffRole.create!( person: p6, permission_id: Permission.hbx_csr_tier2.id, subrole: 'developer', hbx_profile_id: hbx_profile_id)
   end
 end

--- a/app/data_migrations/define_permissions.rb
+++ b/app/data_migrations/define_permissions.rb
@@ -9,7 +9,7 @@ class DefinePermissions < MigrationTask
   	Permission.create(name: 'hbx_staff', modify_family: true, modify_employer: true, revert_application: true, list_enrollments: true,
   	  send_broker_agency_message: true, approve_broker: true, approve_ga: true,
   	  modify_admin_tabs: true, view_admin_tabs: true)
-  	Permission.create(name: 'hbx_read_only', modify_family: false, modify_employer: false, revert_application: false, list_enrollments: true,
+    Permission.create(name: 'hbx_read_only', modify_family: true, modify_employer: false, revert_application: false, list_enrollments: true,
   	  send_broker_agency_message: false, approve_broker: false, approve_ga: false,
   	  modify_admin_tabs: false, view_admin_tabs: true)  
   	Permission.create(name: 'hbx_csr_supervisor', modify_family: true, modify_employer: true, revert_application: true, list_enrollments: true,
@@ -21,6 +21,9 @@ class DefinePermissions < MigrationTask
     Permission.create(name: 'hbx_csr_tier1', modify_family: true, modify_employer: false, revert_application: false, list_enrollments: false,
   	  send_broker_agency_message: false, approve_broker: false, approve_ga: false,
   	  modify_admin_tabs: false, view_admin_tabs: false)
+    Permission.create(name: 'developer', modify_family: false, modify_employer: false, revert_application: false, list_enrollments: true,
+      send_broker_agency_message: false, approve_broker: false, approve_ga: false,
+      modify_admin_tabs: false, view_admin_tabs: true)
   	permission = Permission.hbx_staff
     Person.where(hbx_staff_role: {:$exists => true}).all.each{|p|p.hbx_staff_role.update_attributes(permission_id: permission.id, subrole:'hbx_staff')}
   end

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -31,5 +31,8 @@ class Permission
     def hbx_csr_tier2 
       Permission.where(name: 'hbx_csr_tier2').first 
     end
+    def developer
+      Permission.where(name: 'developer').first
+    end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -152,4 +152,7 @@ puts "importing provider_directory_urls and rx_formulary_urls for plans complete
 puts "*"*80
 
 puts "*"*80
+system "bundle exec rake permissions:initial_hbx"
+
+puts "*"*80
 puts "End of Seed Data"

--- a/spec/data_migrations/permissions_spec.rb
+++ b/spec/data_migrations/permissions_spec.rb
@@ -3,7 +3,7 @@ require File.join(Rails.root, "app", "data_migrations", "define_permissions")
 
 describe DefinePermissions do
   subject { DefinePermissions.new(given_task_name, double(:current_scope => nil))}
-  let(:roles) {%w{hbx_staff hbx_read_only hbx_csr_supervisor hbx_csr_tier2 hbx_csr_tier1} }
+  let(:roles) {%w{hbx_staff hbx_read_only hbx_csr_supervisor hbx_csr_tier2 hbx_csr_tier1 developer} }
   describe 'create permissions' do
     let(:given_task_name) {':initial_hbx'}
     before do
@@ -13,7 +13,7 @@ describe DefinePermissions do
       subject.initial_hbx
     end
     it "creates permissions" do
-    	expect(Permission.count).to eq(5)
+      expect(Permission.count).to eq(6)
     	expect(Person.first.hbx_staff_role.subrole).to eq 'hbx_staff'
       expect(Permission.all.map(&:name)).to match_array roles
     end
@@ -29,11 +29,12 @@ describe DefinePermissions do
       allow(Permission).to receive_message_chain('hbx_csr_supervisor.id'){FactoryGirl.create(:permission, :hbx_csr_supervisor).id}
       allow(Permission).to receive_message_chain('hbx_csr_tier2.id'){FactoryGirl.create(:permission,  :hbx_csr_tier2).id}
       allow(Permission).to receive_message_chain('hbx_csr_tier1.id'){FactoryGirl.create(:permission,  :hbx_csr_tier1).id}
+      allow(Permission).to receive_message_chain('hbx_csr_tier1.id'){FactoryGirl.create(:permission,  :developer).id}
       subject.build_test_roles
     end
     it "creates permissions" do
-      expect(User.all.count).to eq(5)
-      expect(Person.all.count).to eq(5)
+      expect(User.all.count).to eq(6)
+      expect(Person.all.count).to eq(6)
       expect(Person.all.map{|p|p.hbx_staff_role.subrole}).to match_array roles
     end
   end

--- a/spec/factories/permission.rb
+++ b/spec/factories/permission.rb
@@ -14,7 +14,7 @@ FactoryGirl.define do
     end
 
     trait :hbx_read_only do
-      modify_family false
+      modify_family true
       modify_employer false
       revert_application false
       list_enrollments true
@@ -59,6 +59,19 @@ FactoryGirl.define do
       approve_ga false
     	modify_admin_tabs false
     	view_admin_tabs  false
+    end
+
+
+    trait :developer do
+      modify_family false
+      modify_employer false
+      revert_application false
+      list_enrollments false
+      send_broker_agency_message false
+      approve_broker false
+      approve_ga false
+      modify_admin_tabs false
+      view_admin_tabs  false
     end
   end
 end

--- a/spec/policies/person_policy_spec.rb
+++ b/spec/policies/person_policy_spec.rb
@@ -17,7 +17,7 @@ describe PersonPolicy do
 
     it 'hbx_read_only' do 
       allow(hbx_staff_role).to receive(:permission).and_return(FactoryGirl.create(:permission, :hbx_read_only))
-      expect(policy.updateable?).to be false
+      expect(policy.updateable?).to be true
     end
 
     it 'hbx_csr_supervisor' do
@@ -33,6 +33,11 @@ describe PersonPolicy do
     it 'csr_tier1' do 
       allow(hbx_staff_role).to receive(:permission).and_return(FactoryGirl.create(:permission, :hbx_csr_tier1))
       expect(policy.updateable?).to be true 
+    end
+
+    it 'developer' do 
+      allow(hbx_staff_role).to receive(:permission).and_return(FactoryGirl.create(:permission, :developer))
+      expect(policy.updateable?).to be false 
     end
 
   end


### PR DESCRIPTION
### Redmine ticket(s)
* https://devops.dchbx.org/redmine/issues/9871
* (if more)

### Local build result

```
rspec:   4285 examples, 0 failures, 78 pendings
cucumber:  two random failures
58 scenarios (2 failed, 56 passed)
1001 steps (2 failed, 19 skipped, 980 passed)
worked when retried individually
cucumber features/employee/employee_with_future_doh.feature:10 # Scenario: New hire has future enrollment period
cucumber features/employers/employer_profile.feature:46

This code is not executed in production.   It documents changes made in the production console to implement redmine 9871 and improves rake db:seed

```

### Latest rebase/merge tag
*

---

### Data ticket(s) Followup
* (redmine links here - optional)

### Related Pull Requests
* (github links here - optional)

---

### Notes

The Readonly role was altered at the request of Amanda to allow family updating by the CSRs given the role.

1.  We will not run the rake task permissions:initial_hbx in production again but it is modified to reflect the changes made by console in ticket 9871.

2.  A true readonly only role was created by Mel in production.    This role is documented and is called 'developer'

3.  A class helper for .developer is added to Permission for consistency.

4.  rake permissions:initialize_hbx is added to the rake db:seed task for development as it should have been.


#### Peer Review
* The ticket is marked resolved.  

#### Functional Testing
* (For testing locally)

#### Deployment
* (for release manager and/or build manager)

