### PR TITLE
Refs #10647: Fix roster termination rake task

### DIFF
--- a/lib/tasks/hbx_reports/employee_terminations.rake
+++ b/lib/tasks/hbx_reports/employee_terminations.rake
@@ -9,7 +9,7 @@ namespace :reports do
       census_employees = CensusEmployee.unscoped.terminated.where(:employment_terminated_on.gte => (date_start = Date.new(2015,10,1)))
 
       field_names  = %w(
-          employer_name last_name first_name ssn dob aasm_state hired_on employment_terminated_on updated_at 
+          employer_name last_name first_name ssn dob aasm_state hired_on employment_terminated_on updated_at
         )
 
       processed_count = 0
@@ -34,11 +34,11 @@ namespace :reports do
           active_states = %w(registered eligible binder_paid enrolled suspended)
 
           if active_states.include? census_employee.employer_profile.aasm_state
-            csv << field_names.map do |field_name| 
-              if field_name == "ssn"
-                '="' + eval(field_name) + '"'
-              else
+            csv << field_names.map do |field_name|
+              if eval(field_name).to_s.blank? || field_name != "ssn"
                 eval("#{field_name}")
+              elsif field_name == "ssn"
+                '="' + eval(field_name) + '"'
               end
             end
             processed_count += 1


### PR DESCRIPTION
### Redmine ticket(s)
* https://devops.dchbx.org/redmine/issues/10647
* (if more)

### Local build result

```
bundle exec rake parallel:spec[4]
4308 examples, 0 failures, 81 pendings
Took 183 seconds (3:03)

bundle exec cucumber
58 scenarios (58 passed)
1001 steps (1001 passed)
7m3.032s
```

### Latest rebase/merge tag
* 1.9.19

---

### Data ticket(s) Followup
* (https://devops.dchbx.org/redmine/issues/9834)

### Related Pull Requests
* (github links here - optional)

---

### TODOs / Notes
#### Peer Review
* (For code review)

#### Functional Testing
* (For testing locally)

#### Deployment
* (for release manager and/or build manager)

raising error when ssn is nil for a census_employee.

Fixed the issue by checking to see if the field has
empty value, if its empty, then returning nil.