### PR TITLE
Mobile apis new enrolled count - now also does waived

### DIFF
--- a/app/helpers/employers/employer_helper.rb
+++ b/app/helpers/employers/employer_helper.rb
@@ -69,8 +69,9 @@ module Employers::EmployerHelper
              end
   end
 
-  def self.render_employer_summary_json(employer_profile, year, num_enrolled, num_waived, staff, offices, 
-    include_details_url)
+  def self.render_employer_summary_json(employer_profile: nil, year: nil, num_enrolled: nil, 
+                                        num_waived: nil, staff: nil, offices: nil, 
+                                        include_details_url: false)
     renewals_offset_in_months = Settings.aca.shop_market.renewal_application.earliest_start_prior_to_effective_on.months
 
     summary = { 
@@ -96,8 +97,11 @@ module Employers::EmployerHelper
     summary
   end
 
-  def self.render_employer_details_json(employer_profile, year, num_enrolled,  num_waived, total_premium, employer_contribution, employee_contribution)
-    details = render_employer_summary_json(employer_profile, year, num_enrolled, num_waived, nil, nil, false)
+  def self.render_employer_details_json(employer_profile: nil, year: nil, num_enrolled: nil, 
+                                        num_waived: nil, total_premium: nil, 
+                                        employer_contribution: nil, employee_contribution: nil)
+    details = render_employer_summary_json(employer_profile: employer_profile, year: year, 
+                                           num_enrolled: num_enrolled, num_waived: num_waived)
     details[:total_premium] = total_premium
     details[:employer_contribution] = employer_contribution
     details[:employee_contribution] = employee_contribution
@@ -146,7 +150,9 @@ module Employers::EmployerHelper
         staff = all_staff_by_employer_id[er.id]
         plan_year = er.show_plan_year
         enrolled, waived = count_enrolled_and_waived_employees_if_in_open_enrollment(plan_year, TimeKeeper.date_of_record) 
-        render_employer_summary_json(er, plan_year, enrolled, waived, staff, offices, true) 
+        render_employer_summary_json(employer_profile: er, year: plan_year, 
+                                     num_enrolled: enrolled, num_waived: waived, 
+                                     staff: staff, offices: offices, include_details_url: true) 
     end  
   end
 
@@ -158,10 +164,16 @@ module Employers::EmployerHelper
       employee_cost_total = enrollments.map(&:total_employee_cost).sum
       employer_contribution_total = enrollments.map(&:total_employer_contribution).sum
       enrolled, waived = count_enrolled_and_waived_employees(plan_year)
-      render_employer_details_json(employer_profile, plan_year, enrolled, waived, premium_amt_total, 
-                            employer_contribution_total, employee_cost_total)
+      
+      render_employer_details_json(employer_profile: employer_profile, 
+                                   year: plan_year,  
+                                   num_enrolled: enrolled, 
+                                   num_waived: waived, 
+                                   total_premium: premium_amt_total, 
+                                   employer_contribution: employer_contribution_total, 
+                                   employee_contribution: employee_cost_total)
     else
-      render_employer_details_json(employer_profile, nil, nil, nil, nil, nil, nil, nil)
+      render_employer_details_json(employer_profile: employer_profile)
     end
   end
 

--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -902,7 +902,7 @@ class HbxEnrollment
   # then check again inside the map/reduce to get only those enrollments.
   # This avoids undercounting, e.g. two family members working for the same employer. 
   #
-  def self.count_shop_and_health_enrolled_by_benefit_group_assignments(benefit_group_assignments = [])
+  def self.count_shop_and_health_enrolled_and_waived_by_benefit_group_assignments(benefit_group_assignments = [])
     enrolled_or_renewal = HbxEnrollment::ENROLLED_STATUSES + HbxEnrollment::RENEWAL_STATUSES
 
     return [] if benefit_group_assignments.blank?
@@ -939,7 +939,7 @@ class HbxEnrollment
 
     #distinct benefit group assignment ids with at least one valid enrollment
     found_ids = families.map_reduce(map, reduce).out(inline: true).map{|o| o[:_id]}
-    (found_ids & id_list).count
+    [(found_ids & id_list).count, 0] #TODO waived
   end
 
   # def self.covered(enrollments)

--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -904,14 +904,16 @@ class HbxEnrollment
   #
   def self.count_shop_and_health_enrolled_and_waived_by_benefit_group_assignments(benefit_group_assignments = [])
     enrolled_or_renewal = HbxEnrollment::ENROLLED_STATUSES + HbxEnrollment::RENEWAL_STATUSES
+    waived = HbxEnrollment::WAIVED_STATUSES
 
     return [] if benefit_group_assignments.blank?
     id_list = benefit_group_assignments.map(&:id) #.uniq
     families = Family.where(:"households.hbx_enrollments".elem_match => { 
       :"benefit_group_assignment_id".in => id_list, 
-      :aasm_state.in => enrolled_or_renewal, 
+      :aasm_state.in => enrolled_or_renewal + waived, 
       :kind => "employer_sponsored", 
-      :coverage_kind => "health"  
+      :coverage_kind => "health",
+      :is_active => true #???  
     } )
 
 
@@ -924,22 +926,29 @@ class HbxEnrollment
             var enrollment = this.households[h].hbx_enrollments[e];
             if (enrollment.kind == "employer_sponsored" &&
                 enrollment.coverage_kind == "health" &&
-                enrolled_or_renewal.indexOf(enrollment.aasm_state) != -1
-            ) {
-              emit(enrollment.benefit_group_assignment_id, 1) 
+                enrollment.is_active) {
+                emit(enrollment.benefit_group_assignment_id, enrollment.aasm_state)
             }
           } 
         }    
       }
     } 
 
+    #there should really only be one active shop health enrollment per benefit group assignment
+    #so we simply ignore collisons by taking the first one we find 
     reduce = %Q{ 
-      function(key, values) { return values.reduce( function(a,b) { return a + b; }, 0); } 
+      function(key, values) { return values.length ? values[0] : null } 
     }
 
-    #distinct benefit group assignment ids with at least one valid enrollment
-    found_ids = families.map_reduce(map, reduce).out(inline: true).map{|o| o[:_id]}
-    [(found_ids & id_list).count, 0] #TODO waived
+    items = families.map_reduce(map, reduce).out(inline: true)
+
+    [enrolled_or_renewal, waived].map do |statuses|
+        found_ids = items.map do |item| 
+                    item[:_id] if statuses.include? item[:value] 
+        end.compact
+
+        (found_ids & id_list).count
+    end
   end
 
   # def self.covered(enrollments)

--- a/spec/models/hbx_enrollment_spec.rb
+++ b/spec/models/hbx_enrollment_spec.rb
@@ -1723,7 +1723,7 @@ context "A cancelled external enrollment", :dbclean => :after_each do
 end
 
 
-describe HbxEnrollment, type: :model, dbclean: :after_each do
+describe HbxEnrollment, "Scenarios for count_shop_and_health_enrolled_by_benefit_group_assignments", type: :model, dbclean: :after_each do
    
     let!(:employer_profile_cafe)      { FactoryGirl.create(:employer_profile) }
     let!(:employer_profile_salon)     { FactoryGirl.create(:employer_profile) }
@@ -1851,5 +1851,11 @@ describe HbxEnrollment, type: :model, dbclean: :after_each do
          end
 
        # TODO it "should count enrollment for two people in different households in the same family" do
+       # TODO it - two people in the same family/household that work for the same employer
+       # TODO two people in different households in the same family (e.g Bradys)
+       # TODO people with shopped-for-but-not-bought or terminated policies
+       # TODO valid dental but no valid health - waived
+       # TODO not enrolled this year but already enrolled for next year
+       # TODO someone enrolled in two policies -- for instance one via SHOP, and another one privately -- if that's possible -- maybe some kind of enhanced coverage?
     end
 end

--- a/spec/models/hbx_enrollment_spec.rb
+++ b/spec/models/hbx_enrollment_spec.rb
@@ -1828,7 +1828,7 @@ describe HbxEnrollment, "Scenarios for count_shop_and_health_enrolled_by_benefit
           end
     end
       
-    context "count_shop_and_health_enrolled_by_benefit_group_assignments" do
+    context "count_shop_and_health_enrolled_and_waived_by_benefit_group_assignments" do
 
         it "should count enrollment for three people in the same family who work for the same employer, but one has only dental" do
           
@@ -1841,11 +1841,13 @@ describe HbxEnrollment, "Scenarios for count_shop_and_health_enrolled_by_benefit
           cafe_benefit_groups = [benefit_group_assignment_barista, benefit_group_assignment_manager,
             benefit_group_assignment_janitor] 
 
-          #there are three people working at the cafe, but only two have health insurance    
-          expect(HbxEnrollment.count_shop_and_health_enrolled_by_benefit_group_assignments(cafe_benefit_groups)).to be 2
+          #there are three people working at the cafe, but only two have health insurance; none waived    
+          expect(HbxEnrollment.count_shop_and_health_enrolled_and_waived_by_benefit_group_assignments(cafe_benefit_groups)).to eq [2, 0]
 
-          #there is one person working at the salon    
-          expect(HbxEnrollment.count_shop_and_health_enrolled_by_benefit_group_assignments(salon_benefit_groups)).to be 1
+          #there is one person working at the salon, none waived    
+          expect(HbxEnrollment.count_shop_and_health_enrolled_and_waived_by_benefit_group_assignments(salon_benefit_groups)).to eq [1, 0]
+
+
 
            
          end


### PR DESCRIPTION
Bug fix: it turns out that the method plan_year.waived_count fails on employers who are in renewal (this method is currently only used in the admin interface ER Invoices, where it also erroneously gives 0 values for count of waived employees for employers in the process of renewal, as can be seen now in the UI for employers like "Washington Ear, Nose & Allergy Center"). So we now count the waived employees along with the enrolled employees, in our map_reduce function.

This PR is for performance testing on enroll-feature; rspec tests are not yet complete, they will be updated in a subsequent PR.

### Redmine ticket(s)
* https://devops.dchbx.org/redmine/issues/8029

### Local build result

```
bundle exec rake parallel:spec[4]
```
Since this is an API with no user-facing UI, we are not using cucumber tests, only rspec.

### Latest rebase/merge tag
*

---

### Data ticket(s) Followup
* (redmine links here - optional)

### Related Pull Requests
* https://github.com/dchbx/enroll/pull/322
---

### TODOs / Notes
#### Peer Review
* (For code review)

#### Functional Testing
* (For testing locally)

#### Deployment
* (for release manager and/or build manager)
