### PR TITLE
Various Mobile API changes (ready for promotion)

### DIFF
--- a/app/controllers/api/v1/mobile_api_controller.rb
+++ b/app/controllers/api/v1/mobile_api_controller.rb
@@ -28,7 +28,7 @@ module Api
       def my_employer_details
         execute {
           @employer_profile ||= Mobile::EmployerUtil.employer_profile_for_user current_user
-          render_employer @employer_profile!=nil?
+          render_employer !@employer_profile.nil?
         }
       end
 
@@ -42,7 +42,7 @@ module Api
       def my_employee_roster
         execute {
           @employer_profile ||= Mobile::EmployerUtil.employer_profile_for_user current_user
-          render_employees @employer_profile!=nil?
+          render_employees !@employer_profile.nil?
         }
       end
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -2,7 +2,7 @@
 lock '3.3.5'
 
 set :application, 'enroll'
-set :repo_url, 'https://github.com/benjaminrosenbaum/enroll.git'
+set :repo_url, 'https://github.com/dchbx/enroll.git'
 
 # Default branch is :master
 # ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }.call

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -2,7 +2,7 @@
 lock '3.3.5'
 
 set :application, 'enroll'
-set :repo_url, 'https://github.com/dchbx/enroll.git'
+set :repo_url, 'https://github.com/benjaminrosenbaum/enroll.git'
 
 # Default branch is :master
 # ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }.call

--- a/lib/api/v1/mobile/base_util.rb
+++ b/lib/api/v1/mobile/base_util.rb
@@ -9,6 +9,15 @@ module Api
           end
         end
 
+        #
+        # Protected
+        #
+        protected
+
+        def format_date date
+          date.strftime('%m-%d-%Y') if date.respond_to?(:strftime)
+        end
+
       end
     end
   end

--- a/lib/api/v1/mobile/cache_util.rb
+++ b/lib/api/v1/mobile/cache_util.rb
@@ -14,8 +14,8 @@ module Api
             indexed_plans = Plan.where(:'id'.in => plan_ids).index_by(&:id)
             benefit_groups = employer_profile.plan_years.map { |p| p.benefit_groups }.flatten.compact.index_by(&:id)
             enrollments_for_benefit_groups.map { |e|
-              e.plan = indexed_plans[e.plan_id]
-              e.benefit_group = benefit_groups[e.benefit_group_id]
+              e.plan = indexed_plans[e.plan_id] if e.plan_id
+              e.benefit_group = benefit_groups[e.benefit_group_id] if e.benefit_group_id
             }
             result = {employees_benefits: employees_benefits, grouped_bga_enrollments: grouped_bga_enrollments}
           rescue Exception => e
@@ -34,7 +34,7 @@ module Api
           families = Family.where(:'households.hbx_enrollments'.elem_match => {
               :'benefit_group_assignment_id'.in => benefit_group_assignment_ids
           })
-          families.map { |f| f.households.map { |h| h.hbx_enrollments } }.flatten.compact
+          families.map { |f| f.households.map { |h| h.hbx_enrollments.show_enrollments_sans_canceled } }.flatten.compact
         end
 
       end

--- a/spec/lib/api/v1/mobile_api_employer_util_spec.rb
+++ b/spec/lib/api/v1/mobile_api_employer_util_spec.rb
@@ -87,9 +87,6 @@ RSpec.describe Api::V1::Mobile::EmployerUtil, dbclean: :after_each do
       expect(summary[:employer_details_url]).to include('/api/v1/mobile_api/employer_details/')
       expect(summary[:employee_roster_url]).to include('/api/v1/mobile_api/employee_roster/')
       confirm_expected_plan_year_summary_fields_for_cafe summary[:plan_years].first
-      expect(summary[:plan_years].first[:employees_enrolled]).to eq 2
-      expect(summary[:plan_years].first[:employees_waived]).to eq 0
-      expect(summary[:plan_years].first[:employees_terminated]).to eq 0
 
       summary = employer.send(:summary_details, {employer_profile: employer_profile_cafe,
                                                  years: employer_profile_cafe.plan_years,


### PR DESCRIPTION
**Description of changes**

We believe that with the additions in this PR, the dchbx:enhancement-8029 branch is ready to be merged and promoted to the appdev team preprod box for further testing and evaluation.

This PR mainly adds to the API the ability to show multiple plan years in an array distinguished by plan year date (rather than hardwiring notions of "active" and "renewal"), allowing for more flexible UI.

**Master Redmine ticket**
8029

**Local build result**

Since this is an API with no user-facing UI, we are not using cucumber tests, only RSpec.

bundle exec rake spec

Finished in 12 minutes 19 seconds (files took 7.49 seconds to load)
4762 examples, 0 failures, 81 pending

**Related Pull Requests**

dchbx/enroll#667

**TODOs / NotesPeer Review**

(For code review)

**Functional Testing**

(For testing locally)

**Deployment**

(for release manager and/or build manager)