### PR TITLE
rake: Issue #14687 - Add a rake task to migrate Responsible Party enr…

### DIFF
--- a/app/data_migrations/fix_is_subscriber_for_responsible_party_enrollments.rb
+++ b/app/data_migrations/fix_is_subscriber_for_responsible_party_enrollments.rb
@@ -1,0 +1,45 @@
+require File.join(Rails.root, 'lib/mongoid_migration_task')
+
+class FixIsSubscriberForResponsiblePartyEnrollments < MongoidMigrationTask
+  def migrate
+    invalid_is_subscriber_enrollment_ids.each.with_index(1) do |enrollment_id, idx|
+      HbxEnrollment.find(enrollment_id).save
+      puts "#{idx}: Changed the is_subscriber flag for HbxEnrollment ID #{enrollment_id} to true."
+    end
+  end
+
+  private
+
+  def invalid_is_subscriber_enrollment_ids
+    Family.collection.aggregate(
+      [
+        {'$unwind' => '$households'},
+        {'$unwind' => '$households.hbx_enrollments'},
+        {'$unwind' => '$households.hbx_enrollments.hbx_enrollment_members'},
+        {'$match' => {
+          'households.hbx_enrollments' => {'$ne' => nil}
+        }},
+        {'$match' => {
+          'households.hbx_enrollments.hbx_enrollment_members' => {'$ne' => nil},
+          'households.hbx_enrollments.external_enrollment' => {'$ne' => true}
+        }},
+        {'$match' => {
+          'households.hbx_enrollments.consumer_role_id' => {'$ne' => nil},
+          'households.hbx_enrollments.aasm_state' => {'$ne' => 'shopping'}
+        }},
+        {'$match' => {
+          'households.hbx_enrollments.plan_id' => {'$ne' => nil},
+          'households.hbx_enrollments.aasm_state' => {'$nin' => ['shopping', 'inactive', 'coverage_canceled', 'coverage_terminated']}
+        }},
+        {'$group' => {
+          '_id' => '$households.hbx_enrollments._id',
+          'max_hbx_enrollment_member' => {'$max' => '$households.hbx_enrollments.hbx_enrollment_members.is_subscriber'}
+        }},
+        {'$match' => {
+          'max_hbx_enrollment_member' => false
+        }}
+      ],
+      :allow_disk_use => true
+    ).to_a.map { |enrollment| enrollment['_id'].to_s }
+  end
+end

--- a/lib/tasks/migrations/fix_is_subscriber_for_responsible_party_enrollments.rake
+++ b/lib/tasks/migrations/fix_is_subscriber_for_responsible_party_enrollments.rake
@@ -1,0 +1,8 @@
+require File.join(Rails.root, "app", "data_migrations", "fix_is_subscriber_for_responsible_party_enrollments")
+
+# This rake task will search all responsible party enrollments for records where is_subscriber is not set to true.
+# If it finds any, it will set the is_subscriber flag to "true" for the oldest enrollee.
+namespace :migrations do
+  desc "setting the is_subscriber flag to true for the oldest enrollee on responsible party enrollments that don't have a subscriber defined"
+  FixIsSubscriberForResponsiblePartyEnrollments.define_task fix_is_subscriber_for_responsible_party_enrollments: :environment
+end


### PR DESCRIPTION
Add a rake task to migrate Responsible Party enrollments that don't have a subscriber defined.

### Master Redmine ticket
* (14154)

### Child Redmine ticket(s)
* (13099)
* (10690)
* (14687)

### Local build result

```
bundle exec rake parallel:spec[4]
bundle exec cucumber
```

### Latest rebase/merge tag
*

---

### Data ticket(s) Followup
* (redmine links here - optional)

### Related Pull Requests
* (github links here - optional)

---

### TODOs / Notes
#### Peer Review
* (For code review)

#### Functional Testing
* (For testing locally)

#### Deployment
* (for release manager and/or build manager)