### PR TITLE
7048: QLE rule incorrectly applies "first of the month following or coinciding with" logic

### DIFF
--- a/app/controllers/insured/family_members_controller.rb
+++ b/app/controllers/insured/family_members_controller.rb
@@ -34,6 +34,7 @@ class Insured::FamilyMembersController < ApplicationController
       special_enrollment_period = @family.special_enrollment_periods.new(effective_on_kind: params[:effective_on_kind])
       special_enrollment_period.selected_effective_on = Date.strptime(params[:effective_on_date], "%m/%d/%Y") if params[:effective_on_date].present?
       special_enrollment_period.qualifying_life_event_kind = qle
+      special_enrollment_period.change_plan_type = params[:change_plan]
       special_enrollment_period.qle_on = Date.strptime(params[:qle_date], "%m/%d/%Y")
       special_enrollment_period.qle_answer = params[:qle_reason_choice] if params[:qle_reason_choice].present?
       special_enrollment_period.save

--- a/app/models/special_enrollment_period.rb
+++ b/app/models/special_enrollment_period.rb
@@ -8,7 +8,7 @@ class SpecialEnrollmentPeriod
   embeds_many :comments, as: :commentable, cascade_callbacks: true
 
   # for employee gaining medicare qle
-  attr_accessor :selected_effective_on
+  attr_accessor :selected_effective_on, :change_plan_type
 
   field :qualifying_life_event_kind_id, type: BSON::ObjectId
 
@@ -233,7 +233,11 @@ private
 
   def first_of_next_month_effective_date_for_shop
     if @earliest_effective_date == @earliest_effective_date.beginning_of_month
-      @earliest_effective_date
+      if change_plan_type == 'Married'
+        @earliest_effective_date.end_of_month + 1.day
+      else
+        @earliest_effective_date
+      end
     else
       @earliest_effective_date.end_of_month + 1.day
     end

--- a/spec/models/special_enrollment_period_spec.rb
+++ b/spec/models/special_enrollment_period_spec.rb
@@ -380,6 +380,14 @@ RSpec.describe SpecialEnrollmentPeriod, :type => :model do
           sep.qle_on = TimeKeeper.date_of_record.beginning_of_month
           expect(sep.effective_on).to eq TimeKeeper.date_of_record.beginning_of_month
         end
+
+        it "should set effective date to date of event when date of event is beginning of next month" do
+          sep.change_plan_type= 'Married'
+          sep.qualifying_life_event_kind = qle
+          sep.effective_on_kind = "first_of_next_month"
+          sep.qle_on = TimeKeeper.date_of_record.beginning_of_month
+          expect(sep.effective_on).to eq TimeKeeper.date_of_record.end_of_month + 1.day
+        end
       end
 
       it "and qle is fixed_first_of_next_month" do


### PR DESCRIPTION
|Field|Value|
|-----|-----|
| Redmine Ticket Number | [7048](https://devops.dchbx.org/redmine/issues/7048) |
| App-Dev Road Map # | n/a |
| Start Date | 04/29/2016 |
| Due Date | n/a  |
| App-Dev Priority | n/a |
| Development Story Points | 1 |
| Peer Review Story Points | 1 |
| Ticket Author | Chloe Berger |