### PR TITLE
25708: Continuing with blank immigration document type on 'Personal Information' screen yields an internal error

### DIFF
--- a/app/controllers/insured/consumer_roles_controller.rb
+++ b/app/controllers/insured/consumer_roles_controller.rb
@@ -6,7 +6,7 @@ class Insured::ConsumerRolesController < ApplicationController
 
   before_action :check_consumer_role, only: [:search, :match]
   before_action :find_consumer_role, only: [:edit, :update]
-  before_filter :load_support_texts, only: [:edit, :search, :match]
+  before_filter :load_support_texts, only: [:edit, :search, :match, :update]
 
   def ssn_taken
   end


### PR DESCRIPTION
|Field|Value|
|-----|-----|
| Redmine Ticket Number | [25708](https://devops.dchbx.org/redmine/issues/25708) |
| App-Dev Road Map # | n/a |
| Start Date | n/a |
| Due Date | n/a  |
| App-Dev Priority | UP-2 |
| Development Story Points | n/a |
| Peer Review Story Points | n/a |
| Ticket Author | Joshua Karper |