### PR TITLE
Removes Password Requirements unless password validation errors present

### DIFF
--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -9,19 +9,24 @@ module DeviseHelper
                       count: resource.errors.count,
                       resource: resource.class.model_name.human.downcase)
 
-    html = <<-HTML
-    <div class="alert alert-error module registration-rules" role="alert">
-      <div class="text-center">
-        <strong>
-          Password Requirements
-        </strong>
-      </div>
+    top_div = '<div class="alert alert-error module registration-rules" role="alert">'.html_safe
+    
+    if resource.errors.messages.keys.include?(:password)
+      password_div = '
+        <div class="text-center">
+          <strong>
+            Password Requirements
+          </strong>
+        </div>'.html_safe
+    else
+      password_div = ''
+    end
+    error_messages_div = 
+      "
       <br/>
       <strong>#{sentence}</strong>
       <ul>#{messages}</ul>
-    </div>
-    HTML
-
-    html.html_safe
+    </div>".html_safe
+    top_div + password_div + error_messages_div
   end
 end


### PR DESCRIPTION
Given that you're creating a new user, when you submit the form and it has email errors (but not password errors), the "Password Requirements" div still shows up, like so:

<img width="1088" alt="password_valid_but_password_reqs_show" src="https://user-images.githubusercontent.com/13513340/48092152-e4f1ba00-e1d9-11e8-9aa7-0067d2803d16.png">


This PR adds a check to see if there are any password errors first before displaying that div:

<img width="1026" alt="error_with_no_password_validation" src="https://user-images.githubusercontent.com/13513340/48092135-d1deea00-e1d9-11e8-97d4-814890de9261.png">

### Master Redmine ticket
* (Required!)

### Child Redmine ticket(s)
* ()
* ()

### Local build result

```
bundle exec rake parallel:spec[4]
bundle exec cucumber
```

### Latest rebase/merge tag
*

---

### Data ticket(s) Followup
* (redmine links here - optional)

### Related Pull Requests
* (github links here - optional)

---

### TODOs / Notes
#### Peer Review
* (For code review)

#### Functional Testing
* (For testing locally)

#### Deployment
* (for release manager and/or build manager)

### Latest rebase/merge tag
*

---

### Data ticket(s) Followup
* (redmine links here - optional)

### Related Pull Requests
* (github links here - optional)

---

### TODOs / Notes
#### Peer Review
* (For code review)

#### Functional Testing
* (For testing locally)

#### Deployment
* (for release manager and/or build manager)
