### PR TITLE
Put parallel tasks at step level.

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -32,6 +32,7 @@ jobs:
               for test_dir in `ls -1 $root/components/ | grep -v old_sponsored_benefits`; do
                 echo $root/components/$test_dir
                 cd $root/components/$test_dir
+                bundle config path ../../vendor/bundle
                 bundle install
                 bundle exec rspec --fail-fast
                 if [ $? -ne 0 ]; then

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,13 +19,15 @@ jobs:
         mongodb-version: ["3.6"]
         command_configs:
           - name: rspec 1/4
-            test_command: rspec_booster --job 1/4
-          - name: rspec 2/4
-            test_command: rspec_booster --job 2/4
-          - name: rspec 3/4
-            test_command: rspec_booster --job 3/4
-          - name: rspec 4/4
-            test_command: rspec_booster --job 4/4
+            test_command: rspec_booster --job 1/5
+          - name: rspec 2/5
+            test_command: rspec_booster --job 2/5
+          - name: rspec 3/5
+            test_command: rspec_booster --job 3/5
+          - name: rspec 4/5
+            test_command: rspec_booster --job 4/5
+          - name: rspec 5/5
+            test_command: rspec_booster --job 5/5
           - name: engine rspecs
             test_command: |
               root=`pwd -P`

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -128,7 +128,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: node_modules
-        key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
+        key: ${{ runner.os }}-node_modules-${{ hashFiles('./yarn.lock') }}
         restore-keys: |
           ${{ runner.os }}-node_modules-
     - name: bundle install

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -39,10 +39,10 @@ jobs:
                   exit $?
                 fi
               done
-          - name: cucumber 1/3
+          - name: cucumber 1/4
             test_command: |
               export DISPLAY=:99
-              if cucumber_booster --job 1/3 features
+              if cucumber_booster --job 1/4 features
               then
                 echo "Cucumber passed the first time!"
                 exit 0
@@ -58,10 +58,10 @@ jobs:
                 fi
               fi
             needs_chromedriver: true
-          - name: cucumber 2/3
+          - name: cucumber 2/4
             test_command: |
               export DISPLAY=:99
-              if cucumber_booster --job 2/3 features
+              if cucumber_booster --job 2/4 features
               then
                 echo "Cucumber passed the first time!"
                 exit 0
@@ -76,10 +76,29 @@ jobs:
                   bundle exec cucumber tmp/cucumber_failures_2.log --format summary --out cucumber_3.summary --format rerun --out tmp/cucumber_failures_3.log
                 fi
               fi
-          - name: cucumber 3/3
+          - name: cucumber 3/4
             test_command: |
               export DISPLAY=:99
-              if cucumber_booster --job 3/3 features
+              if cucumber_booster --job 3/4 features
+              then
+                echo "Cucumber passed the first time!"
+                exit 0
+              else
+                echo "Give cucumber one more try"
+                if bundle exec cucumber tmp/cucumber_failures.log --format summary --out cucumber_2.summary --format rerun --out tmp/cucumber_failures_2.log
+                then
+                  echo "Cucumber worked on retry"
+                  exit 0
+                else
+                  echo "Give cucumber yet another try"
+                  bundle exec cucumber tmp/cucumber_failures_2.log --format summary --out cucumber_3.summary --format rerun --out tmp/cucumber_failures_3.log
+                fi
+              fi
+            needs_chromedriver: true
+          - name: cucumber 4/4
+            test_command: |
+              export DISPLAY=:99
+              if cucumber_booster --job 4/4 features
               then
                 echo "Cucumber passed the first time!"
                 exit 0

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -122,15 +122,15 @@ jobs:
         path: vendor/bundle
         key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
-          ${{ runner.os }}-gems-
+          ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
     - name: Cache Node Modules
       id: npm-cache
       uses: actions/cache@v1
       with:
         path: node_modules
-        key: ${{ runner.os }}-node_modules-${{ hashFiles('./yarn.lock') }}
+        key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}
         restore-keys: |
-          ${{ runner.os }}-node_modules-
+          ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}
     - name: bundle install
       run: |
         gem update --system

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -2,27 +2,100 @@ name: Rspec and Cucumbers
 on: push
 
 env: # https://stackoverflow.com/questions/59867124/how-can-i-access-github-action-environment-variables-within-a-bash-script-run-by
-  STATUS: failing
   SHA: ${{ github.sha }}
   BRANCH: ${{ github.ref }}
   YELLR_KEY: ${{ secrets.YELLR_KEY }}
   YELLR_URL: ${{ secrets.YELLR_URL }}
+  TEST_BOOSTERS_RSPEC_TEST_FILE_PATTERN: '{spec,components/benefit_markets/spec,components/benefit_sponsors,components/notifier,components/sponsored_benefits,components/transport_gateway,components/transport_profiles}/**/*_spec.rb'
 
 jobs:
-  rspec-1-of-4:
+  testing_matrix:
+    name: ${{matrix.command_configs.name}}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04] #ubuntu-16.04
+        os: [ubuntu-18.04]
         node: [10]
         mongodb-version: ["3.6"]
-
+        command_configs:
+          - name: rspec 1/4
+            test_command: rspec_booster --job 1/4
+          - name: rspec 2/4
+            test_command: rspec_booster --job 2/4
+          - name: rspec 3/4
+            test_command: rspec_booster --job 3/4
+          - name: rspec 4/4
+            test_command: rspec_booster --job 4/4
+          - name: engine rspecs
+            test_command: |
+              root=`pwd -P`
+              for test_dir in `ls -1 $root/components/ | grep -v old_sponsored_benefits`; do
+                echo $root/components/$test_dir
+                cd $root/components/$test_dir
+                bundle install
+                bundle exec rspec --fail-fast
+                if [ $? -ne 0 ]; then
+                  echo "ENGINE FAILED"
+                  exit $?
+                fi
+              done
+          - name: cucumber 1/3
+            test_command: |
+              export DISPLAY=:99
+              if cucumber_booster --job 1/3 features
+              then
+                echo "Cucumber passed the first time!"
+                exit 0
+              else
+                echo "Give cucumber one more try"
+                if bundle exec cucumber tmp/cucumber_failures.log --format summary --out cucumber_2.summary --format rerun --out tmp/cucumber_failures_2.log
+                then
+                  echo "Cucumber worked on retry"
+                  exit 0
+                else
+                  echo "Give cucumber yet another try"
+                  bundle exec cucumber tmp/cucumber_failures_2.log --format summary --out cucumber_3.summary --format rerun --out tmp/cucumber_failures_3.log
+                fi
+              fi
+            needs_chromedriver: true
+          - name: cucumber 2/3
+            test_command: |
+              export DISPLAY=:99
+              if cucumber_booster --job 2/3 features
+              then
+                echo "Cucumber passed the first time!"
+                exit 0
+              else
+                echo "Give cucumber one more try"
+                if bundle exec cucumber tmp/cucumber_failures.log --format summary --out cucumber_2.summary --format rerun --out tmp/cucumber_failures_2.log
+                then
+                  echo "Cucumber worked on retry"
+                  exit 0
+                else
+                  echo "Give cucumber yet another try"
+                  bundle exec cucumber tmp/cucumber_failures_2.log --format summary --out cucumber_3.summary --format rerun --out tmp/cucumber_failures_3.log
+                fi
+              fi
+          - name: cucumber 3/3
+            test_command: |
+              export DISPLAY=:99
+              if cucumber_booster --job 3/3 features
+              then
+                echo "Cucumber passed the first time!"
+                exit 0
+              else
+                echo "Give cucumber one more try"
+                if bundle exec cucumber tmp/cucumber_failures.log --format summary --out cucumber_2.summary --format rerun --out tmp/cucumber_failures_2.log
+                then
+                  echo "Cucumber worked on retry"
+                  exit 0
+                else
+                  echo "Give cucumber yet another try"
+                  bundle exec cucumber tmp/cucumber_failures_2.log --format summary --out cucumber_3.summary --format rerun --out tmp/cucumber_failures_3.log
+                fi
+              fi
+            needs_chromedriver: true
     steps:
-    - name: Launch MongoDB
-      uses: wbari/start-mongoDB@v0.2
-      with:
-        mongoDBVersion: ${{ matrix.mongodb-version }}
-    - uses: actions/checkout@v2
     - name: Set up Ruby 2.5.1
       uses: ruby/setup-ruby@v1
       with:
@@ -32,323 +105,54 @@ jobs:
       with:
         # Version Spec of the version to use.  Examples: 10.x, 10.15.1, >=10.15.0, lts
         version: 10.16.3
-    - name: bundle install, yarn install
-      run: |
-        gem update --system
-        gem install bundler -v '2.0.1'
-        bundle install --jobs 4 --retry 3
-        gem install semaphore_test_boosters
-        yarn install
-        ./bin/webpack
-    - name: rspec
-      run: rspec_booster --job 1/4
-    - name: cat order
-      if: failure()
-      run: for log in order*.log; do echo $log; cat $log; done
-      continue-on-error: true
-    - name: Notify Yellr of failure
-      id: extract_branch
-      if: failure()
-      run: 'curl -H "Content-Type: application/json" -H "X-API-Key: ${{ env.YELLR_KEY }}" -X POST ${{ env.YELLR_URL }} -d "{\"project\":\"enroll_dc\",\"branch\":\"${GITHUB_REF#refs/heads/}\",\"sha\":\"${{ env.SHA }}\",\"status\":\"failing\"}"'
-  rspec-2-of-4:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-18.04] #ubuntu-16.04
-        node: [10]
-        mongodb-version: ["3.6"]
-
-    steps:
     - name: Launch MongoDB
       uses: wbari/start-mongoDB@v0.2
       with:
         mongoDBVersion: ${{ matrix.mongodb-version }}
     - uses: actions/checkout@v2
-    - name: Set up Ruby 2.5.1
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.5.1
-    - name: Setup Node.js for use with actions
-      uses: actions/setup-node@v1.1.0
-      with:
-        # Version Spec of the version to use.  Examples: 10.x, 10.15.1, >=10.15.0, lts
-        version: 10.16.3
-    - name: bundle install, yarn install
-      run: |
-        gem update --system
-        gem install bundler -v '2.0.1'
-        bundle install --jobs 4 --retry 3
-        gem install semaphore_test_boosters
-        yarn install
-        ./bin/webpack
-    - name: rspec
-      run: rspec_booster --job 2/4
-    - name: cat order
-      if: failure()
-      run: for log in order*.log; do echo $log; cat $log; done
-      continue-on-error: true
-    - name: Notify Yellr of failure
-      id: extract_branch
-      if: failure()
-      run: 'curl -H "Content-Type: application/json" -H "X-API-Key: ${{ env.YELLR_KEY }}" -X POST ${{ env.YELLR_URL }} -d "{\"project\":\"enroll_dc\",\"branch\":\"${GITHUB_REF#refs/heads/}\",\"sha\":\"${{ env.SHA }}\",\"status\":\"failing\"}"'
-  rspec-3-of-4:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-18.04] #ubuntu-16.04
-        node: [10]
-        mongodb-version: ["3.6"]
-
-    steps:
-    - name: Launch MongoDB
-      uses: wbari/start-mongoDB@v0.2
-      with:
-        mongoDBVersion: ${{ matrix.mongodb-version }}
-    - uses: actions/checkout@v2
-    - name: Set up Ruby 2.5.1
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.5.1
-    - name: Setup Node.js for use with actions
-      uses: actions/setup-node@v1.1.0
-      with:
-        # Version Spec of the version to use.  Examples: 10.x, 10.15.1, >=10.15.0, lts
-        version: 10.16.3
-    - name: bundle install, yarn install
-      run: |
-        gem update --system
-        gem install bundler -v '2.0.1'
-        bundle install --jobs 4 --retry 3
-        gem install semaphore_test_boosters
-        yarn install
-        ./bin/webpack
-    - name: rspec
-      run: rspec_booster --job 3/4
-    - name: cat order
-      if: failure()
-      run: for log in order*.log; do echo $log; cat $log; done
-      continue-on-error: true
-    - name: Notify Yellr of failure
-      id: extract_branch
-      if: failure()
-      run: 'curl -H "Content-Type: application/json" -H "X-API-Key: ${{ env.YELLR_KEY }}" -X POST ${{ env.YELLR_URL }} -d "{\"project\":\"enroll_dc\",\"branch\":\"${GITHUB_REF#refs/heads/}\",\"sha\":\"${{ env.SHA }}\",\"status\":\"failing\"}"'
-  rspec-4-of-4:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-18.04] #ubuntu-16.04
-        node: [10]
-        mongodb-version: ["3.6"]
-
-    steps:
-    - name: Launch MongoDB
-      uses: wbari/start-mongoDB@v0.2
-      with:
-        mongoDBVersion: ${{ matrix.mongodb-version }}
-    - uses: actions/checkout@v2
-    - name: Set up Ruby 2.5.1
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.5.1
-    - name: Setup Node.js for use with actions
-      uses: actions/setup-node@v1.1.0
-      with:
-        # Version Spec of the version to use.  Examples: 10.x, 10.15.1, >=10.15.0, lts
-        version: 10.16.3
-    - name: bundle install, yarn install
-      run: |
-        gem update --system
-        gem install bundler -v '2.0.1'
-        bundle install --jobs 4 --retry 3
-        gem install semaphore_test_boosters
-        yarn install
-        ./bin/webpack
-    - name: rspec
-      run: rspec_booster --job 4/4
-    - name: cat order
-      if: failure()
-      run: for log in order*.log; do echo $log; cat $log; done
-      continue-on-error: true
-    - name: Notify Yellr of failure
-      id: extract_branch
-      if: failure()
-      run: 'curl -H "Content-Type: application/json" -H "X-API-Key: ${{ env.YELLR_KEY }}" -X POST ${{ env.YELLR_URL }} -d "{\"project\":\"enroll_dc\",\"branch\":\"${GITHUB_REF#refs/heads/}\",\"sha\":\"${{ env.SHA }}\",\"status\":\"failing\"}"'
-  engines-rspecs:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-18.04] #ubuntu-16.04
-        node: [10]
-        mongodb-version: ["3.6"]
-
-    steps:
-    - name: Launch MongoDB
-      uses: wbari/start-mongoDB@v0.2
-      with:
-        mongoDBVersion: ${{ matrix.mongodb-version }}
-    - uses: actions/checkout@v2
-    - name: Set up Ruby 2.5.1
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.5.1
-    - name: Setup Node.js for use with actions
-      uses: actions/setup-node@v1.1.0
-      with:
-        # Version Spec of the version to use.  Examples: 10.x, 10.15.1, >=10.15.0, lts
-        version: 10.16.3
-    - name: bundle install, yarn install
-      run: |
-        gem update --system
-        gem install bundler
-        bundle install --jobs 4 --retry 3
-        yarn install
-        RAILS_ENV=test NODE_ENV=test rake webpacker:compile
-    - name: cd components/engine, rspec
-      run: |
-        root=`pwd -P`
-        for test_dir in `ls -1 $root/components/ | grep -v old_sponsored_benefits`; do
-          echo $root/components/$test_dir
-          cd $root/components/$test_dir
-          bundle install
-          bundle exec rspec --fail-fast
-          if [ $? -ne 0 ]; then
-            echo "ENGINE FAILED"
-            exit $?
-          fi
-        done
-    - name: Notify Yellr of failure
-      id: extract_branch
-      if: failure()
-      run: 'curl -H "Content-Type: application/json" -H "X-API-Key: ${{ env.YELLR_KEY }}" -X POST ${{ env.YELLR_URL }} -d "{\"project\":\"enroll_dc\",\"branch\":\"${GITHUB_REF#refs/heads/}\",\"sha\":\"${{ env.SHA }}\",\"status\":\"failing\"}"'
-  cucumber-1-of-2:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-18.04] #ubuntu-16.04
-        node: [10]
-        mongodb-version: ["3.6"]
-
-    steps:
-    - name: Launch MongoDB
-      uses: wbari/start-mongoDB@v0.2
-      with:
-        mongoDBVersion: ${{ matrix.mongodb-version }}
-    - uses: actions/checkout@v2
-    - name: Set up Ruby 2.5.1
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.5.1
-    - name: Set up Node.js for use with actions
-      uses: actions/setup-node@v1.1.0
-      with:
-        # Version Spec of the version to use.  Examples: 10.x, 10.15.1, >=10.15.0, lts
-        version: 10.16.3
     - name: Set up Chromedriver
+      if: matrix.command_configs.needs_chromedriver
       uses: nanasess/setup-chromedriver@master
       with:
         # Optional: do not specify to match Chrome's version
         chromedriver-version: '77.0.3865.40'
-    - name: bundle install, yarn install
+    - name: Cache Gems
+      uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
+    - name: Cache Node Modules
+      id: npm-cache
+      uses: actions/cache@v1
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-node_modules-
+    - name: bundle install
       run: |
         gem update --system
-        gem install bundler
+        gem install bundler -v '2.0.1'
+        bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
         gem install semaphore_test_boosters
+    - name: yarn install
+      if: steps.npm-cache.outputs.cache-hit != 'true'
+      run: |
         yarn install
-        RAILS_ENV=test NODE_ENV=test rake webpacker:compile
-    - name: cucumber-1-of-2
+    - name: run webpack
       run: |
-        export DISPLAY=:99
-        if cucumber_booster --job 1/2 features
-        then
-          echo "Cucumber passed the first time!"
-          exit 0
-        else
-          echo "Give cucumber one more try"
-          if bundle exec cucumber tmp/cucumber_failures.log --format summary --out cucumber_2.summary --format rerun --out tmp/cucumber_failures_2.log
-          then
-            echo "Cucumber worked on retry"
-            exit 0
-          else
-            echo "Give cucumber yet another try"
-            bundle exec cucumber tmp/cucumber_failures_2.log --format summary --out cucumber_3.summary --format rerun --out tmp/cucumber_failures_3.log
-          fi
-        fi
-    - uses: actions/upload-artifact@v1
-      if: failure()
-      with:
-        name: cucumber-screenshots
-        path: tmp/capybara
-    - name: Notify Yellr of failure
-      id: extract_branch
-      if: failure()
-      run: 'curl -H "Content-Type: application/json" -H "X-API-Key: ${{ env.YELLR_KEY }}" -X POST ${{ env.YELLR_URL }} -d "{\"project\":\"enroll_dc\",\"branch\":\"${GITHUB_REF#refs/heads/}\",\"sha\":\"${{ env.SHA }}\",\"status\":\"failing\"}"'
-  cucumber-2-of-2:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-18.04] #ubuntu-16.04
-        node: [10]
-        mongodb-version: ["3.6"]
-
-    steps:
-    - name: Launch MongoDB
-      uses: wbari/start-mongoDB@v0.2
-      with:
-        mongoDBVersion: ${{ matrix.mongodb-version }}
-    - uses: actions/checkout@v2
-    - name: Set up Ruby 2.5.1
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.5.1
-    - name: Set up Node.js for use with actions
-      uses: actions/setup-node@v1.1.0
-      with:
-        # Version Spec of the version to use.  Examples: 10.x, 10.15.1, >=10.15.0, lts
-        version: 10.16.3
-    - name: Set up Chromedriver
-      uses: nanasess/setup-chromedriver@master
-      with:
-        # Optional: do not specify to match Chrome's version
-        chromedriver-version: '77.0.3865.40'
-    - name: bundle install, yarn install
-      run: |
-        gem update --system
-        gem install bundler
-        bundle install --jobs 4 --retry 3
-        gem install semaphore_test_boosters
-        yarn install
-        RAILS_ENV=test NODE_ENV=test rake webpacker:compile
-    - name: cucumber-2-of-2
-      run: |
-        export DISPLAY=:99
-        if cucumber_booster --job 2/2
-        then
-          echo "Cucumber passed the first time!"
-          exit 0
-        else
-          echo "Give cucumber one more try"
-          if bundle exec cucumber tmp/cucumber_failures.log --format summary --out cucumber_2.summary --format rerun --out tmp/cucumber_failures_2.log
-          then
-            echo "Cucumber worked on retry"
-            exit 0
-          else
-            echo "Give cucumber yet another try"
-            bundle exec cucumber tmp/cucumber_failures_2.log --format summary --out cucumber_3.summary --format rerun --out tmp/cucumber_failures_3.log
-          fi
-        fi
-    - uses: actions/upload-artifact@v1
-      if: failure()
-      with:
-        name: cucumber-screenshots
-        path: tmp/capybara
-    - name: Notify Yellr of failure
-      id: extract_branch
+        NODE_ENV=test RAILS_ENV=test ./bin/webpack
+    - name: run tests
+      run: ${{matrix.command_configs.test_command}}
+    - name: tell Yellr if failed
       if: failure()
       run: 'curl -H "Content-Type: application/json" -H "X-API-Key: ${{ env.YELLR_KEY }}" -X POST ${{ env.YELLR_URL }} -d "{\"project\":\"enroll_dc\",\"branch\":\"${GITHUB_REF#refs/heads/}\",\"sha\":\"${{ env.SHA }}\",\"status\":\"failing\"}"'
   notify-of-success:
     runs-on: ubuntu-latest
-    needs: [rspec-1-of-4, rspec-2-of-4, rspec-3-of-4, rspec-4-of-4, engines-rspecs, cucumber-1-of-2, cucumber-2-of-2]
+    needs: [testing_matrix]
     steps:
     - name: Notify Yellr of success
       run: 'curl -H "Content-Type: application/json" -H "X-API-Key: ${{ env.YELLR_KEY }}" -X POST ${{ env.YELLR_URL }} -d "{\"project\":\"enroll_dc\",\"branch\":\"${GITHUB_REF#refs/heads/}\",\"sha\":\"${{ env.SHA }}\",\"status\":\"passing\"}"'

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -76,6 +76,7 @@ jobs:
                   bundle exec cucumber tmp/cucumber_failures_2.log --format summary --out cucumber_3.summary --format rerun --out tmp/cucumber_failures_3.log
                 fi
               fi
+            needs_chromedriver: true
           - name: cucumber 3/4
             test_command: |
               export DISPLAY=:99


### PR DESCRIPTION
This fixes several issues:
* Toplevel spec runs didn't include engine specs
* Added Caching of Gems and Node Modules
* Fail-fast, so we only report failures once to Yellr